### PR TITLE
Adds policy_id to policy mappings to support fuzzy searching

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/Policy.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/Policy.kt
@@ -54,7 +54,8 @@ data class Policy(
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
         if (params.paramAsBoolean(WITH_TYPE, true)) builder.startObject(POLICY_TYPE)
-        builder.field(DESCRIPTION_FIELD, description)
+        builder.field(POLICY_ID_FIELD, id)
+            .field(DESCRIPTION_FIELD, description)
             .optionalTimeField(LAST_UPDATED_TIME_FIELD, lastUpdatedTime)
             .field(SCHEMA_VERSION_FIELD, schemaVersion)
             .field(DEFAULT_NOTIFICATION_FIELD, defaultNotification)
@@ -66,6 +67,7 @@ data class Policy(
 
     companion object {
         const val POLICY_TYPE = "policy"
+        const val POLICY_ID_FIELD = "policy_id"
         const val DESCRIPTION_FIELD = "description"
         const val NO_ID = ""
         const val LAST_UPDATED_TIME_FIELD = "last_updated_time"
@@ -100,6 +102,7 @@ data class Policy(
                 when (fieldName) {
                     SCHEMA_VERSION_FIELD -> schemaVersion = xcp.longValue()
                     LAST_UPDATED_TIME_FIELD -> lastUpdatedTime = xcp.instant()
+                    POLICY_ID_FIELD -> { /* do nothing as this is an internal field */ }
                     DESCRIPTION_FIELD -> description = xcp.text()
                     // TODO: DefaultNotification.parse(xcp)
                     DEFAULT_NOTIFICATION_FIELD -> defaultNotification = null

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestIndexPolicyAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestIndexPolicyAction.kt
@@ -77,7 +77,7 @@ class RestIndexPolicyAction(
         }
 
         val xcp = request.contentParser()
-        val policy = Policy.parseWithType(xcp, id).copy(lastUpdatedTime = Instant.now())
+        val policy = Policy.parseWithType(xcp = xcp, id = id).copy(lastUpdatedTime = Instant.now())
         val seqNo = request.paramAsLong(IF_SEQ_NO, SequenceNumbers.UNASSIGNED_SEQ_NO)
         val primaryTerm = request.paramAsLong(IF_PRIMARY_TERM, SequenceNumbers.UNASSIGNED_PRIMARY_TERM)
         val refreshPolicy = if (request.hasParam(REFRESH)) {

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -3,6 +3,15 @@
   "properties": {
     "policy": {
       "properties": {
+        "policy_id": {
+          "type" : "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
         "description": {
           "type": "text",
           "fields": {

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/IndexStateManagementRestApiIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/IndexStateManagementRestApiIT.kt
@@ -206,7 +206,7 @@ class IndexStateManagementRestApiIT : IndexStateManagementRestTestCase() {
 
     @Throws(Exception::class)
     fun `test able to fuzzy search policies`() {
-        val policy = createRandomPolicy()
+        val policy = createRandomPolicy(refresh = true)
 
         val request = """
             {
@@ -223,6 +223,6 @@ class IndexStateManagementRestApiIT : IndexStateManagementRestTestCase() {
                 StringEntity(request, APPLICATION_JSON))
         assertEquals("Request failed", RestStatus.OK, response.restStatus())
         val searchResponse = SearchResponse.fromXContent(createParser(jsonXContent, response.entity.content))
-        assertTrue("Did not find policy using fuzzy search", searchResponse.hits.hits.size != 1)
+        assertTrue("Did not find policy using fuzzy search", searchResponse.hits.hits.size == 1)
     }
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/IndexStateManagementRestApiIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/IndexStateManagementRestApiIT.kt
@@ -24,8 +24,12 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomPolicy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util._ID
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util._PRIMARY_TERM
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util._SEQ_NO
+import org.apache.http.entity.ContentType.APPLICATION_JSON
+import org.apache.http.entity.StringEntity
+import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.client.ResponseException
 import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.common.xcontent.json.JsonXContent.jsonXContent
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.test.ESTestCase
 import org.elasticsearch.test.junit.annotations.TestLogging
@@ -198,5 +202,27 @@ class IndexStateManagementRestApiIT : IndexStateManagementRestTestCase() {
     fun `test checking if a non-existent policy exists`() {
         val headResponse = client().makeRequest("HEAD", "$POLICY_BASE_URI/foobarbaz")
         assertEquals("Unexpected status", RestStatus.NOT_FOUND, headResponse.restStatus())
+    }
+
+    @Throws(Exception::class)
+    fun `test able to fuzzy search policies`() {
+        val policy = createRandomPolicy()
+
+        val request = """
+            {
+                "query": {
+                    "query_string": {
+                        "default_field": "${Policy.POLICY_TYPE}.${Policy.POLICY_ID_FIELD}",
+                        "default_operator": "AND",
+                        "query": "*${policy.id.substring(4, 7)}*"
+                    }
+                }
+            }
+        """.trimIndent()
+        val response = client().makeRequest("POST", "$INDEX_STATE_MANAGEMENT_INDEX/_search", emptyMap(),
+                StringEntity(request, APPLICATION_JSON))
+        assertEquals("Request failed", RestStatus.OK, response.restStatus())
+        val searchResponse = SearchResponse.fromXContent(createParser(jsonXContent, response.entity.content))
+        assertTrue("Did not find policy using fuzzy search", searchResponse.hits.hits.size != 1)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We need to support fuzzy searching by policy_id as we expect people to be able to use it when adding policies and searching for them. Elasticsearch doesn't support it on the _uid field so we need to add it ourself to our mappings/documents.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
