### PR TITLE
Adds ReplicaCount action config, action, step, and tests

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ReplicaCountAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ReplicaCountAction.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexstatemanagement.action
+
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ActionConfig.ActionType
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ReplicaCountActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.replicacount.AttemptSetReplicaCountStep
+import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.service.ClusterService
+
+class ReplicaCountAction(
+    clusterService: ClusterService,
+    client: Client,
+    managedIndexMetaData: ManagedIndexMetaData,
+    config: ReplicaCountActionConfig
+) : Action(ActionType.REPLICA_COUNT, config, managedIndexMetaData) {
+
+    private val attemptSetReplicaCountStep = AttemptSetReplicaCountStep(clusterService, client, config, managedIndexMetaData)
+    private val steps = listOf(attemptSetReplicaCountStep)
+
+    override fun getSteps(): List<Step> = steps
+
+    override fun getStepToExecute(): Step = attemptSetReplicaCountStep
+}

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/action/ActionConfig.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/action/ActionConfig.kt
@@ -56,7 +56,8 @@ abstract class ActionConfig(
         CLOSE("close"),
         OPEN("open"),
         READ_ONLY("read_only"),
-        READ_WRITE("read_write");
+        READ_WRITE("read_write"),
+        REPLICA_COUNT("replica_count");
 
         override fun toString(): String {
             return type
@@ -85,6 +86,7 @@ abstract class ActionConfig(
                     ActionType.CLOSE.type -> actionConfig = CloseActionConfig.parse(xcp, index)
                     ActionType.READ_ONLY.type -> actionConfig = ReadOnlyActionConfig.parse(xcp, index)
                     ActionType.READ_WRITE.type -> actionConfig = ReadWriteActionConfig.parse(xcp, index)
+                    ActionType.REPLICA_COUNT.type -> actionConfig = ReplicaCountActionConfig.parse(xcp, index)
                     else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in Action.")
                 }
             }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/replicacount/AttemptSetReplicaCountStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/replicacount/AttemptSetReplicaCountStep.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexstatemanagement.step.replicacount
+
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.suspendUntil
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ReplicaCountActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StepMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
+import org.apache.logging.log4j.LogManager
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
+import org.elasticsearch.action.support.master.AcknowledgedResponse
+import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.common.settings.Settings
+
+class AttemptSetReplicaCountStep(
+    val clusterService: ClusterService,
+    val client: Client,
+    val config: ReplicaCountActionConfig,
+    managedIndexMetaData: ManagedIndexMetaData
+) : Step("attempt_set_replica_count", managedIndexMetaData) {
+
+    private val logger = LogManager.getLogger(javaClass)
+    private var stepStatus = StepStatus.STARTING
+    private var info: Map<String, Any>? = null
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun execute() {
+        val numOfReplicas = config.numOfReplicas
+        try {
+            logger.info("Executing $name on ${managedIndexMetaData.index}")
+            val updateSettingsRequest = UpdateSettingsRequest()
+                    .indices(managedIndexMetaData.index)
+                    .settings(Settings.builder().put("index.number_of_replicas", numOfReplicas))
+            val response: AcknowledgedResponse = client.admin().indices()
+                    .suspendUntil { updateSettings(updateSettingsRequest, it) }
+
+            if (response.isAcknowledged) {
+                logger.info("Successfully executed $name on ${managedIndexMetaData.index}")
+                stepStatus = StepStatus.COMPLETED
+                info = mapOf("message" to "Set number_of_replicas to $numOfReplicas")
+            } else {
+                logger.info("Unsuccessfully executed $name on ${managedIndexMetaData.index}")
+                stepStatus = StepStatus.FAILED
+                info = mapOf("message" to "Failed to set number_of_replicas to $numOfReplicas")
+            }
+        } catch (e: Exception) {
+            logger.error("Failed to execute $name on ${managedIndexMetaData.index}")
+            stepStatus = StepStatus.STARTING
+            val mutableInfo = mutableMapOf("message" to "Failed to set number_of_replicas to $numOfReplicas")
+            val errorMessage = e.message
+            if (errorMessage != null) mutableInfo["cause"] = errorMessage
+            info = mutableInfo.toMap()
+        }
+    }
+
+    override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData {
+        return currentMetaData.copy(
+            stepMetaData = StepMetaData(name, getStepStartTime().toEpochMilli(), stepStatus),
+            transitionTo = null,
+            info = info
+        )
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -243,6 +243,12 @@ abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
     }
 
     @Suppress("UNCHECKED_CAST")
+    protected fun getNumberOfReplicasSetting(indexName: String): Int {
+        val indexSettings = getIndexSettings(indexName) as Map<String, Map<String, Map<String, Any?>>>
+        return (indexSettings[indexName]!!["settings"]!!["index.number_of_replicas"] as String).toInt()
+    }
+
+    @Suppress("UNCHECKED_CAST")
     protected fun getUuid(indexName: String): String {
         val indexSettings = getIndexSettings(indexName) as Map<String, Map<String, Map<String, Any?>>>
         return indexSettings[indexName]!!["settings"]!!["index.uuid"] as String

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/TestHelpers.kt
@@ -26,6 +26,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.A
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.DeleteActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ReadOnlyActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ReadWriteActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ReplicaCountActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.RolloverActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.coordinator.ClusterStateManagedIndexConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.coordinator.SweptManagedIndexConfig
@@ -42,9 +43,6 @@ import org.elasticsearch.common.unit.ByteSizeValue
 import org.elasticsearch.common.unit.TimeValue
 import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.common.xcontent.XContentFactory
-import org.elasticsearch.common.xcontent.XContentParser
-import org.elasticsearch.common.xcontent.XContentParser.Token
-import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.elasticsearch.index.seqno.SequenceNumbers
 import org.elasticsearch.test.rest.ESRestTestCase
 import java.time.Instant
@@ -129,6 +127,10 @@ fun randomReadOnlyActionConfig(): ReadOnlyActionConfig {
 
 fun randomReadWriteActionConfig(): ReadWriteActionConfig {
     return ReadWriteActionConfig(index = 0)
+}
+
+fun randomReplicaCountActionConfig(): ReplicaCountActionConfig {
+    return ReplicaCountActionConfig(index = 0, numOfReplicas = ESRestTestCase.randomIntBetween(0, 200))
 }
 
 /**
@@ -267,6 +269,11 @@ fun ReadWriteActionConfig.toJsonString(): String {
     return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
 }
 
+fun ReplicaCountActionConfig.toJsonString(): String {
+    val builder = XContentFactory.jsonBuilder()
+    return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
+}
+
 fun ChangePolicy.toJsonString(): String {
     val builder = XContentFactory.jsonBuilder()
     return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
@@ -275,42 +282,6 @@ fun ChangePolicy.toJsonString(): String {
 fun ManagedIndexConfig.toJsonString(): String {
     val builder = XContentFactory.jsonBuilder()
     return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
-}
-
-fun parseDeleteActionWithType(xcp: XContentParser): DeleteActionConfig {
-    ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    ensureExpectedToken(Token.FIELD_NAME, xcp.nextToken(), xcp::getTokenLocation)
-    ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    val deleteActionConfig = DeleteActionConfig.parse(xcp, 0)
-    ensureExpectedToken(Token.END_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    return deleteActionConfig
-}
-
-fun parseRolloverActionWithType(xcp: XContentParser): RolloverActionConfig {
-    ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    ensureExpectedToken(Token.FIELD_NAME, xcp.nextToken(), xcp::getTokenLocation)
-    ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    val rolloverActionConfig = RolloverActionConfig.parse(xcp, 0)
-    ensureExpectedToken(Token.END_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    return rolloverActionConfig
-}
-
-fun parseReadOnlyActionWithType(xcp: XContentParser): ReadOnlyActionConfig {
-    ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    ensureExpectedToken(Token.FIELD_NAME, xcp.nextToken(), xcp::getTokenLocation)
-    ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    val readOnlyActionConfig = ReadOnlyActionConfig.parse(xcp, 0)
-    ensureExpectedToken(Token.END_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    return readOnlyActionConfig
-}
-
-fun parseReadWriteActionWithType(xcp: XContentParser): ReadWriteActionConfig {
-    ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    ensureExpectedToken(Token.FIELD_NAME, xcp.nextToken(), xcp::getTokenLocation)
-    ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    val readWriteActionConfig = ReadWriteActionConfig.parse(xcp, 0)
-    ensureExpectedToken(Token.END_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
-    return readWriteActionConfig
 }
 
 /**

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ReplicaCountActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ReplicaCountActionIT.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexstatemanagement.action
+
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateManagementRestTestCase
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.State
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ReplicaCountActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomDefaultNotification
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+class ReplicaCountActionIT : IndexStateManagementRestTestCase() {
+
+    private val testIndexName = javaClass.simpleName.toLowerCase(Locale.ROOT)
+
+    fun `test basic replica count`() {
+        val indexName = "${testIndexName}_index"
+        val policyID = "${testIndexName}_testPolicyName"
+        val actionConfig = ReplicaCountActionConfig(10, 0)
+        val states = listOf(State(name = "ReplicaCountState", actions = listOf(actionConfig), transitions = listOf()))
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            defaultNotification = randomDefaultNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        // create index defaults to 1 replica
+        createIndex(indexName, policyID)
+
+        assertEquals("Index did not default to 1 replica", 1, getNumberOfReplicasSetting(indexName))
+
+        // give time for coordinator to create managed index job
+        Thread.sleep(2000)
+
+        val managedIndexConfig = getManagedIndexConfig(indexName)
+        assertNotNull("ManagedIndexConfig is null", managedIndexConfig)
+
+        // Change the start time so the job will trigger in 2 seconds, this will trigger the first initialization of the policy
+        updateManagedIndexConfigStartTime(managedIndexConfig!!, Instant.now().minusSeconds(58).toEpochMilli())
+        Thread.sleep(3000)
+
+        // Need to speed up to second execution where it will trigger the first execution of the action which
+        // should set the replica count to the desired number
+        updateManagedIndexConfigStartTime(managedIndexConfig, Instant.now().minusSeconds(58).toEpochMilli())
+        Thread.sleep(3000)
+
+        assertEquals("Index did not set number_of_replicas to ${actionConfig.numOfReplicas}", actionConfig.numOfReplicas, getNumberOfReplicasSetting(indexName))
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/XContentTests.kt
@@ -17,16 +17,13 @@ package com.amazon.opendistroforelasticsearch.indexstatemanagement.model
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.nonNullRandomConditions
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.parseDeleteActionWithType
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.parseReadOnlyActionWithType
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.parseReadWriteActionWithType
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.parseRolloverActionWithType
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomChangePolicy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomDeleteActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomManagedIndexConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomPolicy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomReadOnlyActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomReadWriteActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomReplicaCountActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomRolloverActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomState
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomTransition
@@ -82,7 +79,7 @@ class XContentTests : ESTestCase() {
         val deleteActionConfig = randomDeleteActionConfig()
 
         val deleteActionConfigString = deleteActionConfig.toJsonString()
-        val parsedDeleteActionConfig = parseDeleteActionWithType(parserWithType(deleteActionConfigString))
+        val parsedDeleteActionConfig = ActionConfig.parse(parser(deleteActionConfigString), 0)
         assertEquals("Round tripping DeleteActionConfig doesn't work", deleteActionConfig, parsedDeleteActionConfig)
     }
 
@@ -90,7 +87,7 @@ class XContentTests : ESTestCase() {
         val rolloverActionConfig = randomRolloverActionConfig()
 
         val rolloverActionConfigString = rolloverActionConfig.toJsonString()
-        val parsedRolloverActionConfig = parseRolloverActionWithType(parserWithType(rolloverActionConfigString))
+        val parsedRolloverActionConfig = ActionConfig.parse(parser(rolloverActionConfigString), 0)
         assertEquals("Round tripping RolloverActionConfig doesn't work", rolloverActionConfig, parsedRolloverActionConfig)
     }
 
@@ -98,7 +95,7 @@ class XContentTests : ESTestCase() {
         val readOnlyActionConfig = randomReadOnlyActionConfig()
 
         val readOnlyActionConfigString = readOnlyActionConfig.toJsonString()
-        val parsedReadOnlyActionConfig = parseReadOnlyActionWithType(parserWithType(readOnlyActionConfigString))
+        val parsedReadOnlyActionConfig = ActionConfig.parse(parser(readOnlyActionConfigString), 0)
         assertEquals("Round tripping ReadOnlyActionConfig doesn't work", readOnlyActionConfig, parsedReadOnlyActionConfig)
     }
 
@@ -106,8 +103,16 @@ class XContentTests : ESTestCase() {
         val readWriteActionConfig = randomReadWriteActionConfig()
 
         val readWriteActionConfigString = readWriteActionConfig.toJsonString()
-        val parsedReadWriteActionConfig = parseReadWriteActionWithType(parserWithType(readWriteActionConfigString))
+        val parsedReadWriteActionConfig = ActionConfig.parse(parser(readWriteActionConfigString), 0)
         assertEquals("Round tripping ReadWriteActionConfig doesn't work", readWriteActionConfig, parsedReadWriteActionConfig)
+    }
+
+    fun `test replica_count action config parsing`() {
+        val replicaCountActionConfig = randomReplicaCountActionConfig()
+
+        val replicaCountActionConfigString = replicaCountActionConfig.toJsonString()
+        val parsedReplicaCountActionConfig = ActionConfig.parse(parser(replicaCountActionConfigString), 0)
+        assertEquals("Round tripping ReplicaCountActionConfig doesn't work", replicaCountActionConfig, parsedReplicaCountActionConfig)
     }
 
     fun `test managed index config parsing`() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds ReplicaCount action config, action, step, and tests

Did not include a "wait_for" setting to wait for the replica shards to allocate as I can not think of a common/useful use case for that (waiting for an increase in replica count). If someone can think of one please feel free to comment or create a GitHub issue. Adding that setting should be relatively simple w/ an extra wait for step, but until then we'll keep it simple.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
