### PR TITLE
Adds extra validation for policy and state

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/Policy.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/Policy.kt
@@ -42,7 +42,15 @@ data class Policy(
 ) : ToXContentObject {
 
     init {
-        // TODO: Unique valid state names, transitions point to an existing state name
+        val distinctStateNames = states.map { it.name }.distinct()
+        states.forEach { state ->
+            state.transitions.forEach { transition ->
+                require(distinctStateNames.contains(transition.stateName)) {
+                    "Policy contains a transition in state=${state.name} pointing to a nonexistent state=${transition.stateName}"
+                }
+            }
+        }
+        require(distinctStateNames.size == states.size) { "Policy cannot have duplicate state names"}
         require(states.isNotEmpty()) { "Policy must contain at least one State" }
         requireNotNull(states.find { it.name == defaultState }) { "Policy must have a valid default state" }
     }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/State.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/State.kt
@@ -32,6 +32,15 @@ data class State(
 
     init {
         require(name.isNotBlank()) { "State must contain a valid name" }
+        var hasDelete = false
+        actions.forEach { actionConfig ->
+            // dont allow actions after delete as they will never happen
+            require(!hasDelete) { "State=$name must not contain an action after a delete action" }
+            hasDelete = actionConfig.type == ActionConfig.ActionType.DELETE
+        }
+
+        // dont allow transitions if state contains delete
+        if (hasDelete) require(transitions.isEmpty()) { "State=$name cannot contain transitions if using delete action" }
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/PolicyTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/PolicyTests.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexstatemanagement.model
+
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomPolicy
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomState
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomTransition
+import org.elasticsearch.test.ESTestCase
+import kotlin.test.assertFailsWith
+
+class PolicyTests : ESTestCase() {
+
+    fun `test invalid default state`() {
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for invalid default state") {
+            randomPolicy().copy(defaultState = "definitely not this")
+        }
+    }
+
+    fun `test empty states`() {
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for empty states") {
+            randomPolicy().copy(states = emptyList())
+        }
+    }
+
+    fun `test duplicate states`() {
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for duplicate states") {
+            val states = listOf(randomState(name = "duplicate"), randomState(), randomState(name = "duplicate"))
+            randomPolicy(states = states)
+        }
+    }
+
+    fun `test transition pointing to nonexistent state`() {
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for nonexistent transition state") {
+            val states = listOf(randomState(transitions = listOf(randomTransition(stateName = "doesnt exist"))), randomState(), randomState())
+            randomPolicy(states = states)
+        }
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/StateTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/StateTests.kt
@@ -15,6 +15,10 @@
 
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.model
 
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomDeleteActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomReplicaCountActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomState
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomTransition
 import org.elasticsearch.test.ESTestCase
 import kotlin.test.assertFailsWith
 
@@ -27,6 +31,18 @@ class StateTests : ESTestCase() {
 
         assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for empty state name") {
             State("", emptyList(), emptyList())
+        }
+    }
+
+    fun `test transitions disallowed if using delete`() {
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for transitions when using delete") {
+            randomState(actions = listOf(randomDeleteActionConfig()), transitions = listOf(randomTransition()))
+        }
+    }
+
+    fun `test action disallowed if used after delete`() {
+        assertFailsWith(IllegalArgumentException::class, "Expected IllegalArgumentException for action if used after delete") {
+            randomState(actions = listOf(randomDeleteActionConfig(), randomReplicaCountActionConfig()))
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds extra validation for policy and state
1. States in a policy must all have unique names
2. Transitions must have a valid state_name
3. No actions are allowed after delete (as they will never happen)
4. No transitions are allowed in a state with delete (as it will never happen)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
