### PR TITLE
Correctly updates rolledover

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -145,7 +145,7 @@ class AttemptRolloverStep(
     override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData {
         return currentMetaData.copy(
             stepMetaData = StepMetaData(name, getStepStartTime().toEpochMilli(), stepStatus),
-            // TODO we should refactor such that transitionTo is not reset in the step.
+            rolledOver = if (currentMetaData.rolledOver == true) true else stepStatus == StepStatus.COMPLETED,
             transitionTo = null,
             info = info
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Correctly sets rolledover flag as it was not being set before
If the index was already rolledover then the step will be FAILED so we cannot just check the stepStatus. We will first check if it's already rolledover and if it was return the same, otherwise we check if the step was completed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
