### PR TITLE
Consistent mappings for transition/rollover fields

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/Transition.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/Transition.kt
@@ -89,17 +89,17 @@ data class Conditions(
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         builder.startObject()
-        if (indexAge != null) builder.field(INDEX_AGE_FIELD, indexAge.stringRep)
-        if (docCount != null) builder.field(DOC_COUNT_FIELD, docCount)
-        if (size != null) builder.field(SIZE_FIELD, size.stringRep)
+        if (indexAge != null) builder.field(MIN_INDEX_AGE_FIELD, indexAge.stringRep)
+        if (docCount != null) builder.field(MIN_DOC_COUNT_FIELD, docCount)
+        if (size != null) builder.field(MIN_SIZE_FIELD, size.stringRep)
         if (cron != null) builder.field(CRON_FIELD, cron)
         return builder.endObject()
     }
 
     companion object {
-        const val INDEX_AGE_FIELD = "index_age"
-        const val DOC_COUNT_FIELD = "doc_count"
-        const val SIZE_FIELD = "size"
+        const val MIN_INDEX_AGE_FIELD = "min_index_age"
+        const val MIN_DOC_COUNT_FIELD = "min_doc_count"
+        const val MIN_SIZE_FIELD = "min_size"
         const val CRON_FIELD = "cron"
 
         @JvmStatic
@@ -116,9 +116,9 @@ data class Conditions(
                 xcp.nextToken()
 
                 when (fieldName) {
-                    INDEX_AGE_FIELD -> indexAge = TimeValue.parseTimeValue(xcp.text(), INDEX_AGE_FIELD)
-                    DOC_COUNT_FIELD -> docCount = xcp.longValue()
-                    SIZE_FIELD -> size = ByteSizeValue.parseBytesSizeValue(xcp.text(), SIZE_FIELD)
+                    MIN_INDEX_AGE_FIELD -> indexAge = TimeValue.parseTimeValue(xcp.text(), MIN_INDEX_AGE_FIELD)
+                    MIN_DOC_COUNT_FIELD -> docCount = xcp.longValue()
+                    MIN_SIZE_FIELD -> size = ByteSizeValue.parseBytesSizeValue(xcp.text(), MIN_SIZE_FIELD)
                     CRON_FIELD -> cron = ScheduleParser.parse(xcp) as? CronSchedule
                     else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in Conditions.")
                 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/TestHelpers.kt
@@ -94,9 +94,9 @@ fun randomConditions(
     val value = condition.second
 
     return when (type) {
-        Conditions.INDEX_AGE_FIELD -> Conditions(indexAge = value as TimeValue)
-        Conditions.DOC_COUNT_FIELD -> Conditions(docCount = value as Long)
-        Conditions.SIZE_FIELD -> Conditions(size = value as ByteSizeValue)
+        Conditions.MIN_INDEX_AGE_FIELD -> Conditions(indexAge = value as TimeValue)
+        Conditions.MIN_DOC_COUNT_FIELD -> Conditions(docCount = value as Long)
+        Conditions.MIN_SIZE_FIELD -> Conditions(size = value as ByteSizeValue)
 //        Conditions.CRON_FIELD -> Conditions(cron = value as CronSchedule) // TODO: Uncomment after issues are fixed
         else -> throw IllegalArgumentException("Invalid field: [$type] given for random Conditions.")
     }
@@ -143,11 +143,11 @@ fun randomForceMergeActionConfig(
 /**
  * Helper functions for creating a random Conditions object
  */
-fun randomIndexAge(indexAge: TimeValue = randomTimeValueObject()) = Conditions.INDEX_AGE_FIELD to indexAge
+fun randomIndexAge(indexAge: TimeValue = randomTimeValueObject()) = Conditions.MIN_INDEX_AGE_FIELD to indexAge
 
-fun randomDocCount(docCount: Long = ESRestTestCase.randomLongBetween(1, 1000)) = Conditions.DOC_COUNT_FIELD to docCount
+fun randomDocCount(docCount: Long = ESRestTestCase.randomLongBetween(1, 1000)) = Conditions.MIN_DOC_COUNT_FIELD to docCount
 
-fun randomSize(size: ByteSizeValue = randomByteSizeValue()) = Conditions.SIZE_FIELD to size
+fun randomSize(size: ByteSizeValue = randomByteSizeValue()) = Conditions.MIN_SIZE_FIELD to size
 
 fun randomCronSchedule(cron: CronSchedule = CronSchedule("0 * * * *", ZoneId.of("UTC"))) =
     Conditions.CRON_FIELD to cron

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionRetryIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionRetryIT.kt
@@ -23,7 +23,7 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
         val testPolicy = """
         {"policy":{"description":"Default policy","default_state":"Ingest","states":[
         {"name":"Ingest","actions":[{"retry":{"count":2,"backoff":"constant","delay":"1s"},"rollover":{"min_doc_count":100}}],"transitions":[{"state_name":"Search"}]},
-        {"name":"Search","actions":[],"transitions":[{"state_name":"Delete","conditions":{"index_age":"30d"}}]},
+        {"name":"Search","actions":[],"transitions":[{"state_name":"Delete","conditions":{"min_index_age":"30d"}}]},
         {"name":"Delete","actions":[{"delete":{}}],"transitions":[]}]}}
         """.trimIndent()
 
@@ -94,7 +94,7 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
         val testPolicy = """
         {"policy":{"description":"Default policy","default_state":"Ingest","states":[
         {"name":"Ingest","actions":[{"retry":{"count":2,"backoff":"exponential","delay":"1m"},"rollover":{"min_doc_count":100}}],"transitions":[{"state_name":"Search"}]},
-        {"name":"Search","actions":[],"transitions":[{"state_name":"Delete","conditions":{"index_age":"30d"}}]},
+        {"name":"Search","actions":[],"transitions":[{"state_name":"Delete","conditions":{"min_index_age":"30d"}}]},
         {"name":"Delete","actions":[{"delete":{}}],"transitions":[]}]}}
         """.trimIndent()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Consistent mappings for transition/rollover fields
We have the same concept of min index age, size, doc count but they had slightly different mappings. Slightly confusing to have to remember which is which when creating policy, so this simplifies it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
