### PR TITLE
Fixes Retry API not resetting action startTime

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/managedindexmetadata/ActionMetaData.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/managedindexmetadata/ActionMetaData.kt
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets
 
 data class ActionMetaData(
     val name: String,
-    val startTime: Long,
+    val startTime: Long?,
     val index: Int,
     val failed: Boolean,
     val consumedRetries: Int,
@@ -45,7 +45,7 @@ data class ActionMetaData(
 
     override fun writeTo(out: StreamOutput) {
         out.writeString(name)
-        out.writeLong(startTime)
+        out.writeOptionalLong(startTime)
         out.writeInt(index)
         out.writeBoolean(failed)
         out.writeInt(consumedRetries)
@@ -85,7 +85,7 @@ data class ActionMetaData(
 
         fun fromStreamInput(si: StreamInput): ActionMetaData {
             val name: String? = si.readString()
-            val startTime: Long? = si.readLong()
+            val startTime: Long? = si.readOptionalLong()
             val index: Int? = si.readInt()
             val failed: Boolean? = si.readBoolean()
             val consumedRetries: Int? = si.readInt()
@@ -95,7 +95,7 @@ data class ActionMetaData(
 
             return ActionMetaData(
                 requireNotNull(name) { "$NAME is null" },
-                requireNotNull(startTime) { "$START_TIME is null" },
+                startTime,
                 requireNotNull(index) { "$INDEX is null" },
                 requireNotNull(failed) { "$FAILED is null" },
                 requireNotNull(consumedRetries) { "$CONSUMED_RETRIES is null" },
@@ -133,7 +133,7 @@ data class ActionMetaData(
 
                 when (fieldName) {
                     NAME -> name = xcp.text()
-                    START_TIME -> startTime = xcp.longValue()
+                    START_TIME -> startTime = if (xcp.currentToken() == Token.VALUE_NULL) null else xcp.longValue()
                     INDEX -> index = xcp.intValue()
                     FAILED -> failed = xcp.booleanValue()
                     CONSUMED_RETRIES -> consumedRetries = xcp.intValue()
@@ -145,7 +145,7 @@ data class ActionMetaData(
 
             return ActionMetaData(
                 requireNotNull(name) { "$NAME is null" },
-                requireNotNull(startTime) { "$START_TIME is null" },
+                startTime,
                 requireNotNull(index) { "$INDEX is null" },
                 requireNotNull(failed) { "$FAILED is null" },
                 requireNotNull(consumedRetries) { "$CONSUMED_RETRIES is null" },

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
@@ -152,7 +152,7 @@ class RestRetryFailedManagedIndexAction(
                         Pair(Index(managedIndexMetaData.index, managedIndexMetaData.indexUuid), managedIndexMetaData.copy(
                             stepMetaData = null,
                             policyRetryInfo = PolicyRetryInfoMetaData(false, 0),
-                            actionMetaData = managedIndexMetaData.actionMetaData?.copy(failed = false, consumedRetries = 0, lastRetryTime = null),
+                            actionMetaData = managedIndexMetaData.actionMetaData?.copy(failed = false, consumedRetries = 0, lastRetryTime = null, startTime = null),
                             transitionTo = startState,
                             info = mapOf("message" to "Attempting to retry")
                         ))

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
@@ -134,7 +134,7 @@ class WaitForForceMergeStep(
     }
 
     private fun getActionStartTime(): Instant {
-        if (managedIndexMetaData.actionMetaData == null) {
+        if (managedIndexMetaData.actionMetaData?.startTime == null) {
             return Instant.now()
         }
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -292,7 +292,8 @@ fun Action.getUpdatedActionMetaData(managedIndexMetaData: ManagedIndexMetaData, 
             ActionMetaData(this.type.type, Instant.now().toEpochMilli(), this.config.actionIndex, false, 0, 0, null)
         actionMetaData?.index != this.config.actionIndex ->
             ActionMetaData(this.type.type, Instant.now().toEpochMilli(), this.config.actionIndex, false, 0, 0, null)
-        else -> actionMetaData
+        // RetryAPI will reset startTime to null for actionMetaData and we'll reset it to "now" here
+        else -> actionMetaData.copy(startTime = actionMetaData.startTime ?: Instant.now().toEpochMilli())
     }
 }
 

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -197,7 +197,7 @@ abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
                 }
             }
         """.trimIndent()
-        val response = client().makeRequest("PUT", "_cluster/settings", emptyMap(),
+        client().makeRequest("PUT", "_cluster/settings", emptyMap(),
             StringEntity(request, APPLICATION_JSON))
     }
 
@@ -426,7 +426,11 @@ abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
     protected fun assertActionEquals(expectedAction: ActionMetaData, actualActionMap: Any?): Boolean {
         actualActionMap as Map<String, Any>
         assertEquals(expectedAction.name, actualActionMap[ManagedIndexMetaData.NAME] as String)
-        assertTrue((actualActionMap[ManagedIndexMetaData.START_TIME] as Long) < expectedAction.startTime)
+        assertEquals(expectedAction.failed, actualActionMap[ActionMetaData.FAILED] as Boolean)
+        val expectedStartTime = expectedAction.startTime
+        if (expectedStartTime != null) {
+            assertTrue((actualActionMap[ManagedIndexMetaData.START_TIME] as Long) < expectedStartTime)
+        }
         return true
     }
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionRetryIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionRetryIT.kt
@@ -64,11 +64,7 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
         Thread.sleep(3000)
 
         // At this point we should see in the explain API the action has failed with correct number of consumed retries.
-        val response = client().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$indexName")
-        assertEquals("Unexpected RestStatus", RestStatus.OK, response.restStatus())
-
         val expectedInfoString = mapOf("message" to "There is no valid rollover_alias=null set on $indexName").toString()
-        val actual = response.asMap()
         assertPredicatesOnMetaData(
             listOf(
                 indexName to listOf(
@@ -91,7 +87,7 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
                     ManagedIndexMetaData.INFO to fun(info: Any?): Boolean = expectedInfoString == info.toString()
                 )
             ),
-            actual
+            getExplainMap(indexName)
         )
     }
 
@@ -138,12 +134,8 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
         updateManagedIndexConfigStartTime(managedIndexConfig, Instant.now().minusSeconds(58).toEpochMilli())
         Thread.sleep(3000)
 
-        val response = client().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$indexName")
-        assertEquals("Unexpected RestStatus", RestStatus.OK, response.restStatus())
-
         // even if we ran couple times we should have backed off and only retried once.
         val expectedInfoString = mapOf("message" to "There is no valid rollover_alias=null set on $indexName").toString()
-        val actual = response.asMap()
         assertPredicatesOnMetaData(
             listOf(
                 indexName to listOf(
@@ -165,8 +157,6 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
                         assertRetryInfoEquals(PolicyRetryInfoMetaData(false, 0), retryInfoMetaDataMap),
                     ManagedIndexMetaData.INFO to fun(info: Any?): Boolean = expectedInfoString == info.toString()
                 )
-            ),
-            actual
-        )
+            ), getExplainMap(indexName))
     }
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/NotificationActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/NotificationActionIT.kt
@@ -76,7 +76,7 @@ class NotificationActionIT : IndexStateManagementRestTestCase() {
         val managedIndexConfig = getExistingManagedIndexConfig(indexName)
 
         // Change the start time so the job will trigger in 2 seconds, this will trigger the first initialization of the policy
-        updateManagedIndexConfigStartTime(managedIndexConfig!!, Instant.now().minusSeconds(58).toEpochMilli())
+        updateManagedIndexConfigStartTime(managedIndexConfig, Instant.now().minusSeconds(58).toEpochMilli())
 
         waitFor {
             assertPredicatesOnMetaData(

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -328,7 +328,6 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         }
 
         // We should expect the explain API to show us in the ReadOnlyAction
-        val nextExplainResponse = client().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$index")
         assertPredicatesOnMetaData(
             listOf(
                 index to listOf(
@@ -342,7 +341,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
                             assertActionEquals(ActionMetaData(name = ActionConfig.ActionType.READ_ONLY.type, startTime = Instant.now().toEpochMilli(), index = 0,
                                     failed = false, consumedRetries = 0, lastRetryTime = null, actionProperties = null), actionMetaDataMap)
                 )
-            ), nextExplainResponse.asMap(), false)
+            ), getExplainMap(index), false)
 
         // speed up to third execution so that we try to move to transitions and trigger a change policy
         updateManagedIndexConfigStartTime(
@@ -361,7 +360,6 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         }
 
         // We should expect the explain API to show us with the new policy
-        val changedExplainResponse = client().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$index")
         assertPredicatesOnMetaData(
             listOf(
                 index to listOf(
@@ -375,7 +373,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
                             assertActionEquals(ActionMetaData(name = ActionConfig.ActionType.TRANSITION.type, startTime = Instant.now().toEpochMilli(), index = 0,
                                     failed = false, consumedRetries = 0, lastRetryTime = null, actionProperties = null), actionMetaDataMap)
                 )
-            ), changedExplainResponse.asMap(), false)
+            ), getExplainMap(index), false)
     }
 
     fun `test change policy API should only apply to indices in the state filter`() {
@@ -513,7 +511,6 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         }
 
         // should expect to see us starting in the state mentioned in changepolicy
-        val explainResponse = client().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$index")
         assertPredicatesOnMetaData(
             listOf(
                 index to listOf(
@@ -522,6 +519,6 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
                     StateMetaData.STATE to fun(stateMetaDataMap: Any?): Boolean =
                             assertStateEquals(StateMetaData("some_other_state", Instant.now().toEpochMilli()), stateMetaDataMap)
                 )
-            ), explainResponse.asMap(), false)
+            ), getExplainMap(index), false)
     }
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
@@ -304,7 +304,6 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
         assertAffectedIndicesResponseIsEqual(expectedErrorMessage, response.asMap())
 
         // verify actionStartTime was reset to null
-        val resetExplainResponse = client().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$indexName")
         assertPredicatesOnMetaData(
             listOf(
                 indexName to listOf(
@@ -314,7 +313,7 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
                         return actionMetaDataMap[ManagedIndexMetaData.START_TIME] as Long? == null
                     }
                 )
-            ), resetExplainResponse.asMap(), false)
+            ), getExplainMap(indexName), false)
 
         // should execute and set the startTime again
         updateManagedIndexConfigStartTime(
@@ -324,7 +323,6 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
 
         // the new startTime should be greater than the first start time
         waitFor {
-            val lastExplainResponse = client().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$indexName")
             assertPredicatesOnMetaData(
                 listOf(
                     indexName to listOf(
@@ -334,7 +332,7 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
                             return actionMetaDataMap[ManagedIndexMetaData.START_TIME] as Long > firstStartTime
                         }
                     )
-                ), lastExplainResponse.asMap(), false)
+                ), getExplainMap(indexName), false)
         }
     }
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
@@ -2,6 +2,15 @@ package com.amazon.opendistroforelasticsearch.indexstatemanagement.resthandler
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateManagementRestTestCase
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.makeRequest
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.State
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.ActionMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StateMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomForceMergeActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomPolicy
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomReplicaCountActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomState
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.FAILED_INDICES
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.FAILURES
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.UPDATED_INDICES
@@ -211,6 +220,121 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
                 FAILED_INDICES to emptyList<Map<String, Any>>()
             )
             assertAffectedIndicesResponseIsEqual(expectedErrorMessage, actualMessage)
+        }
+    }
+
+    fun `test reset action start time`() {
+        val indexName = "${testIndexName}_drewberry"
+        val policyID = "${testIndexName}_policy_1"
+        val policy = randomPolicy(states = listOf(randomState(actions = listOf(randomForceMergeActionConfig(maxNumSegments = 1)))))
+        createPolicy(policy, policyId = policyID, refresh = true)
+        createIndex(indexName, policyID)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        // init policy on job
+        updateManagedIndexConfigStartTime(
+            managedIndexConfig,
+            Instant.now().minusSeconds(58).toEpochMilli()
+        )
+
+        // verify we have policy
+        waitFor {
+            assertPredicatesOnMetaData(
+                listOf(indexName to listOf(ManagedIndexMetaData.POLICY_ID to policyID::equals)),
+                getExplainMap(indexName),
+                false
+            )
+        }
+
+        // speed up to execute first action, readonly
+        updateManagedIndexConfigStartTime(
+            managedIndexConfig,
+            Instant.now().minusSeconds(58).toEpochMilli()
+        )
+
+        waitFor {
+            assertPredicatesOnMetaData(
+                listOf(
+                    indexName to listOf(
+                        ActionMetaData.ACTION to fun(actionMetaDataMap: Any?): Boolean =
+                            assertActionEquals(ActionMetaData(name = "force_merge", startTime = Instant.now().toEpochMilli(), failed = false,
+                                index = 0, consumedRetries = 0, lastRetryTime = null, actionProperties = null), actionMetaDataMap)
+                    )
+                ), getExplainMap(indexName), false)
+        }
+
+        // close the index to cause next execution to fail
+        closeIndex(indexName)
+
+        // speed up to execute first action and fail, call force merge
+        updateManagedIndexConfigStartTime(
+            managedIndexConfig,
+            Instant.now().minusSeconds(58).toEpochMilli()
+        )
+
+        // verify failed and save the startTime
+        var firstStartTime: Long = Long.MAX_VALUE
+        waitFor {
+            assertPredicatesOnMetaData(
+                listOf(
+                    indexName to listOf(
+                        ActionMetaData.ACTION to fun(actionMetaDataMap: Any?): Boolean {
+                            @Suppress("UNCHECKED_CAST")
+                            actionMetaDataMap as Map<String, Any>
+                            firstStartTime = actionMetaDataMap[ManagedIndexMetaData.START_TIME] as Long
+                            return assertActionEquals(ActionMetaData(name = "force_merge", startTime = Instant.now().toEpochMilli(), failed = true,
+                                index = 0, consumedRetries = 0, lastRetryTime = null, actionProperties = null), actionMetaDataMap)
+                        }
+                    )
+                ), getExplainMap(indexName), false)
+        }
+
+        // retry
+        val response = client().makeRequest(
+            RestRequest.Method.POST.toString(),
+            "${RestRetryFailedManagedIndexAction.RETRY_BASE_URI}/$indexName"
+        )
+        assertEquals("Unexpected RestStatus", RestStatus.OK, response.restStatus())
+        val expectedErrorMessage = mapOf(
+            UPDATED_INDICES to 1,
+            FAILURES to false,
+            FAILED_INDICES to emptyList<Map<String, Any>>()
+        )
+        assertAffectedIndicesResponseIsEqual(expectedErrorMessage, response.asMap())
+
+        // verify actionStartTime was reset to null
+        val resetExplainResponse = client().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$indexName")
+        assertPredicatesOnMetaData(
+            listOf(
+                indexName to listOf(
+                    ActionMetaData.ACTION to fun(actionMetaDataMap: Any?): Boolean {
+                        @Suppress("UNCHECKED_CAST")
+                        actionMetaDataMap as Map<String, Any>
+                        return actionMetaDataMap[ManagedIndexMetaData.START_TIME] as Long? == null
+                    }
+                )
+            ), resetExplainResponse.asMap(), false)
+
+        // should execute and set the startTime again
+        updateManagedIndexConfigStartTime(
+            managedIndexConfig,
+            Instant.now().minusSeconds(58).toEpochMilli()
+        )
+
+        // the new startTime should be greater than the first start time
+        waitFor {
+            val lastExplainResponse = client().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$indexName")
+            assertPredicatesOnMetaData(
+                listOf(
+                    indexName to listOf(
+                        ActionMetaData.ACTION to fun(actionMetaDataMap: Any?): Boolean {
+                            @Suppress("UNCHECKED_CAST")
+                            actionMetaDataMap as Map<String, Any>
+                            return actionMetaDataMap[ManagedIndexMetaData.START_TIME] as Long > firstStartTime
+                        }
+                    )
+                ), lastExplainResponse.asMap(), false)
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes Retry API not resetting action startTime
Resets action startTime to null when calling retry API
And on first execution in runner after retrying it will use the current time as the new start time

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
