### PR TITLE
Updates SWEEP_PERIOD to higher value

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/settings/ManagedIndexSettings.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/settings/ManagedIndexSettings.kt
@@ -40,10 +40,9 @@ class ManagedIndexSettings {
             Setting.Property.Dynamic
         )
 
-        // TODO: Change this to a higher value after development is finished
         val SWEEP_PERIOD = Setting.positiveTimeSetting(
             "opendistro.index_state_management.coordinator.sweep_period",
-            TimeValue.timeValueMinutes(1),
+            TimeValue.timeValueMinutes(5),
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As we are getting closer to our initial release this updates SWEEP_PERIOD to higher value as it was 1 minute for development purposes. If you still need this lower for testing something on a local cluster just set the value back to 1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
