### PR TITLE
Only do stats request in transition if there is a need

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -178,14 +178,14 @@ fun getSweptManagedIndexSearchRequest(): SearchRequest {
 @Suppress("ReturnCount")
 fun Transition.evaluateConditions(
     indexCreationDate: Instant,
-    numDocs: Long,
-    indexSize: ByteSizeValue,
+    numDocs: Long?,
+    indexSize: ByteSizeValue?,
     transitionStartTime: Instant
 ): Boolean {
     // If there are no conditions, treat as always true
     if (this.conditions == null) return true
 
-    if (this.conditions.docCount != null) {
+    if (this.conditions.docCount != null && numDocs != null) {
         return this.conditions.docCount <= numDocs
     }
 
@@ -194,7 +194,7 @@ fun Transition.evaluateConditions(
         return this.conditions.indexAge.millis <= elapsedTime
     }
 
-    if (this.conditions.size != null) {
+    if (this.conditions.size != null && indexSize != null) {
         return this.conditions.size <= indexSize
     }
 
@@ -206,6 +206,8 @@ fun Transition.evaluateConditions(
     // We should never reach this
     return false
 }
+
+fun Transition.hasStatsConditions(): Boolean = this.conditions?.docCount != null || this.conditions?.size != null
 
 @Suppress("ReturnCount")
 fun RolloverActionConfig.evaluateConditions(

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -360,7 +360,7 @@ abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
         val xcp = createParser(XContentType.JSON.xContent(), response.entity.content)
         ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
         while (xcp.nextToken() != Token.END_OBJECT) {
-            val fieldName = xcp.currentName()
+            xcp.currentName()
             xcp.nextToken()
 
             metadata = ManagedIndexMetaData.parse(xcp)

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionRetryIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionRetryIT.kt
@@ -26,7 +26,7 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
 
         val indexName = "${testIndexName}_index_1"
         val policyID = "${testIndexName}_testPolicyName_1"
-        val policyResponse = createPolicyJson(testPolicy, policyID)
+        createPolicyJson(testPolicy, policyID)
         val expectedInfoString = mapOf("message" to "There is no valid rollover_alias=null set on $indexName").toString()
 
         createIndex(indexName, policyID)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was a bug where going from closing an index -> transitions would fail because you can't do an IndicesStatsRequest on a closed index. This fixes that by only doing the IndicesStatsRequest if the user actually uses a stats condition. So now you can correctly close an index and still transition based off index age or cron conditions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
