### PR TITLE
Fixes bug when updating/removing ManagedIndexMetaData

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
@@ -401,13 +401,13 @@ object ManagedIndexRunner : ScheduledJobRunner,
                 if (response.isAcknowledged) {
                     result = true
                 } else {
-                    logger.error("Failed to save ManagedIndexMetaData")
+                    logger.error("Failed to save ManagedIndexMetaData for [index=${managedIndexMetaData.index}]")
                 }
             }
         } catch (e: ClusterBlockException) {
             logger.error("There was ClusterBlockException trying to update the metadata for ${managedIndexMetaData.index}. Message: ${e.message}", e)
         } catch (e: Exception) {
-            logger.error("Failed to save ManagedIndexMetaData", e)
+            logger.error("Failed to save ManagedIndexMetaData for [index=${managedIndexMetaData.index}]", e)
         }
         return result
     }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/elasticapi/ElasticExtensions.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/elasticapi/ElasticExtensions.kt
@@ -158,6 +158,15 @@ fun IndexMetaData.shouldDeleteManagedIndexConfig(previousIndexMetaData: IndexMet
 }
 
 /**
+ * Checks to see if the [ManagedIndexMetaData] should be removed.
+ *
+ * If [getPolicyID] returns null but [ManagedIndexMetaData] is not null then the policy was removed and
+ * the [ManagedIndexMetaData] remains and should be removed.
+ */
+fun IndexMetaData.shouldDeleteManagedIndexMetaData(): Boolean =
+    this.getPolicyID() == null && this.getManagedIndexMetaData() != null
+
+/**
  * Returns the current policy_id if it exists and is valid otherwise returns null.
  * */
 fun IndexMetaData.getPolicyID(): String? {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
These changes fix two issues:
1. The conditions for removing ManagedIndexMetaData was being incorrectly evaluated, sometimes attempting to delete MetaData which does not exist, leading to a NullPointerException
2. For some integration tests, the runner would finish execution after the index is deleted, attempting to update MetaData which does not exist, leading to a NullPointerException

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
