### PR TITLE
Uses indexmetadata from master node

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
@@ -541,6 +541,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
                 .clear()
                 .indices(index)
                 .metaData(true)
+                .local(false)
                 .indicesOptions(IndicesOptions.strictExpand())
 
             val response: ClusterStateResponse = client.admin().cluster().suspendUntil { state(clusterStateRequest, it) }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestAddPolicyAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestAddPolicyAction.kt
@@ -83,6 +83,7 @@ class RestAddPolicyAction(settings: Settings, controller: RestController) : Base
             .clear()
             .indices(*indices)
             .metaData(true)
+            .local(false)
             .waitForTimeout(TimeValue.timeValueMillis(ADD_POLICY_TIMEOUT_IN_MILLIS))
             .indicesOptions(strictExpandOptions)
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyAction.kt
@@ -108,6 +108,7 @@ class RestChangePolicyAction(
                 .clear()
                 .indices(*indices)
                 .metaData(true)
+                .local(false)
                 .indicesOptions(IndicesOptions.strictExpand())
 
             client.admin().cluster().state(clusterStateRequest, ActionListener.wrap(::processResponse, ::onFailure))

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestExplainAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestExplainAction.kt
@@ -67,6 +67,7 @@ class RestExplainAction(
         clusterStateRequest.clear()
             .indices(*indices)
             .metaData(true)
+            .local(false)
             .local(request.paramAsBoolean("local", clusterStateRequest.local()))
             .masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()))
             .indicesOptions(strictExpandIndicesOptions)

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRemovePolicyAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRemovePolicyAction.kt
@@ -70,6 +70,7 @@ class RestRemovePolicyAction(settings: Settings, controller: RestController) : B
             .clear()
             .indices(*indices)
             .metaData(true)
+            .local(false)
             .indicesOptions(strictExpandOptions)
 
         return RestChannelConsumer {

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
@@ -84,6 +84,7 @@ class RestRetryFailedManagedIndexAction(
         clusterStateRequest.clear()
             .indices(*indices)
             .metaData(true)
+            .local(false)
             .masterNodeTimeout(request.paramAsTime("master_timeout", clusterStateRequest.masterNodeTimeout()))
             .indicesOptions(strictExpandIndicesOptions)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The local indexmetadata from clusterstate could be stale, we need to read it in from the master cluster state each execution. This could potentially be a problem for users that have a very large amount of managed indices. But, we currently have no workaround at the moment so if this does become an issue we can come back to it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
