### PR TITLE
Adds safe change policy logic

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
@@ -389,7 +389,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
         managedIndexConfig: ManagedIndexConfig,
         policyID: String
     ): ManagedIndexMetaData {
-        // we either have init any yet or we have already init metadata but still have no policy
+        // we either haven't initialized any metadata yet or we have already initialized metadata but still have no policy
         return managedIndexMetaData?.copy(
             policyRetryInfo = PolicyRetryInfoMetaData(failed = true, consumedRetries = 0),
             info = mapOf("message" to "Fail to load policy: $policyID")

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/ChangePolicy.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/ChangePolicy.kt
@@ -38,7 +38,7 @@ data class ChangePolicy(
     val policyID: String,
     val state: String?,
     val include: List<StateFilter>,
-    val safe: Boolean
+    val isSafe: Boolean
 ) : ToXContentObject {
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -46,7 +46,7 @@ data class ChangePolicy(
             .startObject()
                 .field(ManagedIndexConfig.POLICY_ID_FIELD, policyID)
                 .field(StateMetaData.STATE, state)
-                .field(SAFE_FIELD, safe)
+                .field(IS_SAFE_FIELD, isSafe)
             .endObject()
         return builder
     }
@@ -55,14 +55,14 @@ data class ChangePolicy(
         const val POLICY_ID_FIELD = "policy_id"
         const val STATE_FIELD = "state"
         const val INCLUDE_FIELD = "include"
-        const val SAFE_FIELD = "safe"
+        const val IS_SAFE_FIELD = "is_safe"
 
         @JvmStatic
         @Throws(IOException::class)
         fun parse(xcp: XContentParser): ChangePolicy {
             var policyID: String? = null
             var state: String? = null
-            var safe: Boolean = false
+            var isSafe: Boolean = false
             val include = mutableListOf<StateFilter>()
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp::getTokenLocation)
@@ -79,7 +79,7 @@ data class ChangePolicy(
                             include.add(StateFilter.parse(xcp))
                         }
                     }
-                    SAFE_FIELD -> safe = xcp.booleanValue()
+                    IS_SAFE_FIELD -> isSafe = xcp.booleanValue()
                     else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in ChangePolicy.")
                 }
             }
@@ -88,7 +88,7 @@ data class ChangePolicy(
                 requireNotNull(policyID) { "ChangePolicy policy id is null" },
                 state,
                 include.toList(),
-                safe
+                isSafe
             )
         }
     }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/ChangePolicy.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/ChangePolicy.kt
@@ -37,7 +37,8 @@ import java.io.IOException
 data class ChangePolicy(
     val policyID: String,
     val state: String?,
-    val include: List<StateFilter>
+    val include: List<StateFilter>,
+    val safe: Boolean
 ) : ToXContentObject {
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
@@ -45,6 +46,7 @@ data class ChangePolicy(
             .startObject()
                 .field(ManagedIndexConfig.POLICY_ID_FIELD, policyID)
                 .field(StateMetaData.STATE, state)
+                .field(SAFE_FIELD, safe)
             .endObject()
         return builder
     }
@@ -53,12 +55,14 @@ data class ChangePolicy(
         const val POLICY_ID_FIELD = "policy_id"
         const val STATE_FIELD = "state"
         const val INCLUDE_FIELD = "include"
+        const val SAFE_FIELD = "safe"
 
         @JvmStatic
         @Throws(IOException::class)
         fun parse(xcp: XContentParser): ChangePolicy {
             var policyID: String? = null
             var state: String? = null
+            var safe: Boolean = false
             val include = mutableListOf<StateFilter>()
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp::getTokenLocation)
@@ -75,6 +79,7 @@ data class ChangePolicy(
                             include.add(StateFilter.parse(xcp))
                         }
                     }
+                    SAFE_FIELD -> safe = xcp.booleanValue()
                     else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in ChangePolicy.")
                 }
             }
@@ -82,7 +87,8 @@ data class ChangePolicy(
             return ChangePolicy(
                 requireNotNull(policyID) { "ChangePolicy policy id is null" },
                 state,
-                include.toList()
+                include.toList(),
+                safe
             )
         }
     }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/coordinator/ClusterStateManagedIndexConfig.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/coordinator/ClusterStateManagedIndexConfig.kt
@@ -15,14 +15,9 @@
 
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.model.coordinator
 
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.optionalTimeField
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ChangePolicy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexConfig
-import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.common.xcontent.ToXContentObject
-import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.index.seqno.SequenceNumbers
-import java.time.Instant
 
 /**
  * Data class to hold index metadata from cluster state.
@@ -37,20 +32,4 @@ data class ClusterStateManagedIndexConfig(
     val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
     val uuid: String,
     val policyID: String
-) : ToXContentObject {
-
-    /**
-     * Used in the partial update of ManagedIndices when picking up changes
-     * from [com.amazon.opendistroforelasticsearch.indexstatemanagement.ManagedIndexCoordinator]
-     */
-    override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        builder
-            .startObject()
-                .startObject(ManagedIndexConfig.MANAGED_INDEX_TYPE)
-                .optionalTimeField(ManagedIndexConfig.LAST_UPDATED_TIME_FIELD, Instant.now())
-                .field(ManagedIndexConfig.CHANGE_POLICY_FIELD, ChangePolicy(policyID, null, emptyList()))
-                .endObject()
-            .endObject()
-        return builder
-    }
-}
+)

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/coordinator/SweptManagedIndexConfig.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/coordinator/SweptManagedIndexConfig.kt
@@ -17,6 +17,7 @@ package com.amazon.opendistroforelasticsearch.indexstatemanagement.model.coordin
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ChangePolicy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
 import org.elasticsearch.common.xcontent.XContentParser
 import org.elasticsearch.common.xcontent.XContentParser.Token
 import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
@@ -34,6 +35,7 @@ data class SweptManagedIndexConfig(
     val primaryTerm: Long,
     val uuid: String,
     val policyID: String,
+    val policy: Policy?,
     val changePolicy: ChangePolicy?
 ) {
 
@@ -44,6 +46,7 @@ data class SweptManagedIndexConfig(
             lateinit var index: String
             lateinit var uuid: String
             lateinit var policyID: String
+            var policy: Policy? = null
             var changePolicy: ChangePolicy? = null
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp::getTokenLocation)
@@ -55,6 +58,9 @@ data class SweptManagedIndexConfig(
                     ManagedIndexConfig.INDEX_FIELD -> index = xcp.text()
                     ManagedIndexConfig.INDEX_UUID_FIELD -> uuid = xcp.text()
                     ManagedIndexConfig.POLICY_ID_FIELD -> policyID = xcp.text()
+                    ManagedIndexConfig.POLICY_FIELD -> {
+                        policy = if (xcp.currentToken() == Token.VALUE_NULL) null else Policy.parse(xcp)
+                    }
                     ManagedIndexConfig.CHANGE_POLICY_FIELD -> {
                         changePolicy = if (xcp.currentToken() == Token.VALUE_NULL) null else ChangePolicy.parse(xcp)
                     }
@@ -62,12 +68,13 @@ data class SweptManagedIndexConfig(
             }
 
             return SweptManagedIndexConfig(
-                    requireNotNull(index) { "SweptManagedIndexConfig index is null" },
-                    seqNo,
-                    primaryTerm,
-                    requireNotNull(uuid) { "SweptManagedIndexConfig uuid is null" },
-                    requireNotNull(policyID) { "SweptManagedIndexConfig policy id is null" },
-                    changePolicy
+                requireNotNull(index) { "SweptManagedIndexConfig index is null" },
+                seqNo,
+                primaryTerm,
+                requireNotNull(uuid) { "SweptManagedIndexConfig uuid is null" },
+                requireNotNull(policyID) { "SweptManagedIndexConfig policy id is null" },
+                policy,
+                changePolicy
             )
         }
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyAction.kt
@@ -21,11 +21,13 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.get
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.getPolicyID
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ChangePolicy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.coordinator.SweptManagedIndexConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.FAILED_INDICES
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.FAILURES
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.FailedIndex
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.UPDATED_INDICES
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.isSafeToChange
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.updateManagedIndexRequest
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.action.ActionListener
@@ -33,6 +35,8 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse
 import org.elasticsearch.action.bulk.BulkRequest
 import org.elasticsearch.action.bulk.BulkResponse
+import org.elasticsearch.action.get.GetRequest
+import org.elasticsearch.action.get.GetResponse
 import org.elasticsearch.action.search.SearchRequest
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.action.support.IndicesOptions
@@ -101,9 +105,32 @@ class RestChangePolicyAction(
 
         private val failedIndices = mutableListOf<FailedIndex>()
         private val managedIndexUuids = mutableListOf<Pair<String, String>>()
+        private val indexUuidToCurrentState = mutableMapOf<String, String>()
+        lateinit var policy: Policy
+
+        fun start() {
+            val getRequest = GetRequest(INDEX_STATE_MANAGEMENT_INDEX, changePolicy.policyID)
+
+            client.get(getRequest, ActionListener.wrap(::onGetPolicyResponse, ::onFailure))
+        }
+
+        private fun onGetPolicyResponse(response: GetResponse) {
+            if (!response.isExists || response.isSourceEmpty) {
+                return channel.sendResponse(BytesRestResponse(RestStatus.NOT_FOUND, "Could not find policy=${changePolicy.policyID}"))
+            }
+
+            policy = XContentHelper.createParser(
+                channel.request().xContentRegistry,
+                LoggingDeprecationHandler.INSTANCE,
+                response.sourceAsBytesRef,
+                XContentType.JSON
+            ).use { Policy.parseWithType(it, response.id, response.seqNo, response.primaryTerm) }
+
+            getClusterState()
+        }
 
         @Suppress("SpreadOperator")
-        fun start() {
+        private fun getClusterState() {
             val clusterStateRequest = ClusterStateRequest()
                 .clear()
                 .indices(*indices)
@@ -118,26 +145,27 @@ class RestChangePolicyAction(
             val includedStates = changePolicy.include.map { it.state }.toSet()
             response.state.metaData.indices.forEach {
                 val indexMetaData = it.value
+                val currentState = indexMetaData.getManagedIndexMetaData()?.stateMetaData?.name
+                if (currentState != null) {
+                    indexUuidToCurrentState[indexMetaData.indexUUID] = currentState
+                }
                 when {
                     // If there is no policyID on the index then it's not currently being managed
-                    indexMetaData.getPolicyID() == null -> failedIndices
-                            .add(FailedIndex(indexMetaData.index.name, indexMetaData.index.uuid, INDEX_NOT_MANAGED))
+                    indexMetaData.getPolicyID() == null ->
+                        failedIndices.add(FailedIndex(indexMetaData.index.name, indexMetaData.index.uuid, INDEX_NOT_MANAGED))
                     // else if there exists a transitionTo on the ManagedIndexMetaData then we will
                     // fail as they might not of meant to add a ChangePolicy when its on the next state
-                    indexMetaData.getManagedIndexMetaData()?.transitionTo != null -> failedIndices
-                            .add(FailedIndex(indexMetaData.index.name, indexMetaData.index.uuid, INDEX_IN_TRANSITION))
-                    // else if there is no ManagedIndexMetaData yet then the managed index has not initialized and
-                    // we can change the policy safely
-                    indexMetaData.getManagedIndexMetaData() == null -> managedIndexUuids
-                            .add(indexMetaData.index.name to indexMetaData.index.uuid)
-                    // else if the includedStates is empty (i.e. not being used) then
-                    // we will always try to update the managed index
+                    indexMetaData.getManagedIndexMetaData()?.transitionTo != null ->
+                        failedIndices.add(FailedIndex(indexMetaData.index.name, indexMetaData.index.uuid, INDEX_IN_TRANSITION))
+                    // else if there is no ManagedIndexMetaData yet then the managed index has not initialized and we can change the policy safely
+                    indexMetaData.getManagedIndexMetaData() == null ->
+                        managedIndexUuids.add(indexMetaData.index.name to indexMetaData.index.uuid)
+                    // else if the includedStates is empty (i.e. not being used) then we will always try to update the managed index
                     includedStates.isEmpty() -> managedIndexUuids.add(indexMetaData.index.name to indexMetaData.index.uuid)
                     // else only update the managed index if its currently in one of the included states
                     includedStates.contains(indexMetaData.getManagedIndexMetaData()?.stateMetaData?.name) ->
                         managedIndexUuids.add(indexMetaData.index.name to indexMetaData.index.uuid)
-                    // else the managed index did not match any of the included state filters and we will not
-                    // update it
+                    // else the managed index did not match any of the included state filters and we will not update it
                     else -> log.debug("Skipping ${indexMetaData.index.name} as it does not match any of the include state filters")
                 }
             }
@@ -180,7 +208,11 @@ class RestChangePolicyAction(
             val mapOfItemIdToIndex = mutableMapOf<Int, Pair<String, String>>()
             val bulkRequest = BulkRequest()
             sweptConfigs.forEachIndexed { index, sweptConfig ->
-                bulkRequest.add(updateManagedIndexRequest(sweptConfig.copy(changePolicy = changePolicy)))
+                // compare the sweptconfig policy to the get policy here and update changePolicy
+                val currentStateName = indexUuidToCurrentState[sweptConfig.uuid]
+                val updatedChangePolicy = changePolicy
+                    .copy(safe = sweptConfig.policy?.isSafeToChange(currentStateName, policy, changePolicy) == true)
+                bulkRequest.add(updateManagedIndexRequest(sweptConfig.copy(changePolicy = updatedChangePolicy)))
                 mapOfItemIdToIndex[index] = sweptConfig.index to sweptConfig.uuid
             }
             client.bulk(bulkRequest, onBulkResponse(mapOfItemIdToIndex))
@@ -231,6 +263,7 @@ class RestChangePolicyAction(
                         "${ManagedIndexConfig.MANAGED_INDEX_TYPE}.${ManagedIndexConfig.INDEX_FIELD}",
                         "${ManagedIndexConfig.MANAGED_INDEX_TYPE}.${ManagedIndexConfig.INDEX_UUID_FIELD}",
                         "${ManagedIndexConfig.MANAGED_INDEX_TYPE}.${ManagedIndexConfig.POLICY_ID_FIELD}",
+                        "${ManagedIndexConfig.MANAGED_INDEX_TYPE}.${ManagedIndexConfig.POLICY_FIELD}",
                         "${ManagedIndexConfig.MANAGED_INDEX_TYPE}.${ManagedIndexConfig.CHANGE_POLICY_FIELD}"
                     ),
                     emptyArray()

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyAction.kt
@@ -211,7 +211,7 @@ class RestChangePolicyAction(
                 // compare the sweptconfig policy to the get policy here and update changePolicy
                 val currentStateName = indexUuidToCurrentState[sweptConfig.uuid]
                 val updatedChangePolicy = changePolicy
-                    .copy(safe = sweptConfig.policy?.isSafeToChange(currentStateName, policy, changePolicy) == true)
+                    .copy(isSafe = sweptConfig.policy?.isSafeToChange(currentStateName, policy, changePolicy) == true)
                 bulkRequest.add(updateManagedIndexRequest(sweptConfig.copy(changePolicy = updatedChangePolicy)))
                 mapOfItemIdToIndex[index] = sweptConfig.index to sweptConfig.uuid
             }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -20,6 +20,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateMana
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.ManagedIndexCoordinator
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.action.Action
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.optionalTimeField
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ChangePolicy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Transition
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
@@ -305,6 +306,7 @@ fun Action.shouldBackoff(actionMetaData: ActionMetaData?, actionRetry: ActionRet
     return this.config.configRetry?.backoff?.shouldBackoff(actionMetaData, actionRetry)
 }
 
+@Suppress("ReturnCount")
 fun Action.hasTimedOut(actionMetaData: ActionMetaData?): Boolean {
     if (actionMetaData?.startTime == null) return false
     val configTimeout = this.config.configTimeout
@@ -400,7 +402,9 @@ val ManagedIndexMetaData.isFailed: Boolean
  * We will change the policy if a change policy exists and if we are currently in
  * a Transitions action (which means we're safely at the end of a state). If a
  * transitionTo exists on the [ManagedIndexMetaData] it should still be fine to
- * change policy as we have not actually transitioned yet.
+ * change policy as we have not actually transitioned yet. If the next action is a transition.
+ * Or if the rest API determined it was "safe". Meaning the new policy has the same structure
+ * of the current state so it should be safe to immediately change even in the middle of the state.
  *
  * @param managedIndexMetaData current [ManagedIndexMetaData]
  * @return {@code true} if we should change policy, {@code false} if not
@@ -409,6 +413,10 @@ val ManagedIndexMetaData.isFailed: Boolean
 fun ManagedIndexConfig.shouldChangePolicy(managedIndexMetaData: ManagedIndexMetaData, actionToExecute: Action?): Boolean {
     if (this.changePolicy == null) {
         return false
+    }
+
+    if (this.changePolicy.safe) {
+        return true
     }
 
     // we need this in so that we can change policy before the first transition happens so policy doesnt get completed
@@ -441,4 +449,39 @@ fun ManagedIndexConfig.hasDifferentJobInterval(jobInterval: Int): Boolean {
         }
     }
     return false
+}
+
+/**
+ * A policy is safe to change to a new policy when each policy has the current state
+ * the [ManagedIndexConfig] is in and that state has the same actions in the same order.
+ * This allows simple things like configuration updates to happen which won't break the execution/contract
+ * between [ManagedIndexMetaData] and [ManagedIndexConfig] as the metadata only knows about the current state.
+ * We never consider a policy safe to immediately change if the ChangePolicy contains a state to transition to.
+ *
+ * @param stateName the name of the state the [ManagedIndexConfig] is currently in
+ * @param nextPolicy the new policy we will eventually try to change to
+ * @return if its safe to change
+ */
+@Suppress("ReturnCount")
+fun Policy.isSafeToChange(stateName: String?, nextPolicy: Policy, changePolicy: ChangePolicy): Boolean {
+    // if stateName is null it means we either have not initialized the job (no metadata to pull stateName from)
+    // or we failed to load the initial policy, both cases its safe to change the policy
+    if (stateName == null) return true
+    if (changePolicy.state != null) return false
+    val currentState = this.states.find { it.name == stateName }
+    val nextState = nextPolicy.states.find { it.name == stateName }
+    if (currentState == null || nextState == null) {
+        return false
+    }
+
+    if (currentState.actions.size != nextState.actions.size) {
+        return false
+    }
+
+    currentState.actions.forEachIndexed { index, action ->
+        val nextStateAction = nextState.actions[index]
+        if (action.type != nextStateAction.type) return@isSafeToChange false
+    }
+
+    return true
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -463,13 +463,13 @@ fun ManagedIndexConfig.hasDifferentJobInterval(jobInterval: Int): Boolean {
  * @return if its safe to change
  */
 @Suppress("ReturnCount")
-fun Policy.isSafeToChange(stateName: String?, nextPolicy: Policy, changePolicy: ChangePolicy): Boolean {
+fun Policy.isSafeToChange(stateName: String?, newPolicy: Policy, changePolicy: ChangePolicy): Boolean {
     // if stateName is null it means we either have not initialized the job (no metadata to pull stateName from)
     // or we failed to load the initial policy, both cases its safe to change the policy
     if (stateName == null) return true
     if (changePolicy.state != null) return false
     val currentState = this.states.find { it.name == stateName }
-    val nextState = nextPolicy.states.find { it.name == stateName }
+    val nextState = newPolicy.states.find { it.name == stateName }
     if (currentState == null || nextState == null) {
         return false
     }

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -363,6 +363,9 @@
             },
             "state": {
               "type": "keyword"
+            },
+            "safe": {
+              "type": "boolean"
             }
           }
         },

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -364,7 +364,7 @@
             "state": {
               "type": "keyword"
             },
-            "safe": {
+            "is_safe": {
               "type": "boolean"
             }
           }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/TestHelpers.kt
@@ -22,6 +22,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ErrorNot
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.State
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.StateFilter
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Transition
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.DeleteActionConfig
@@ -220,9 +221,11 @@ fun randomByteSizeValue() =
 
 fun randomChangePolicy(
     policyID: String = ESRestTestCase.randomAlphaOfLength(10),
-    state: String? = if (ESRestTestCase.randomBoolean()) ESRestTestCase.randomAlphaOfLength(10) else null
+    state: String? = if (ESRestTestCase.randomBoolean()) ESRestTestCase.randomAlphaOfLength(10) else null,
+    include: List<StateFilter> = emptyList(),
+    safe: Boolean = false
 ): ChangePolicy {
-    return ChangePolicy(policyID, state, emptyList())
+    return ChangePolicy(policyID, state, include, safe)
 }
 
 // will only return null since we dont want to send actual notifications during integ tests
@@ -278,7 +281,8 @@ fun randomSweptManagedIndexConfig(
     policyID: String = ESRestTestCase.randomAlphaOfLength(10),
     seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
     primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM,
-    changePolicy: ChangePolicy? = null
+    changePolicy: ChangePolicy? = null,
+    policy: Policy? = null
 ): SweptManagedIndexConfig {
     return SweptManagedIndexConfig(
         index = index,
@@ -286,6 +290,7 @@ fun randomSweptManagedIndexConfig(
         policyID = policyID,
         seqNo = seqNo,
         primaryTerm = primaryTerm,
+        policy = policy,
         changePolicy = changePolicy
     )
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/TestHelpers.kt
@@ -223,9 +223,9 @@ fun randomChangePolicy(
     policyID: String = ESRestTestCase.randomAlphaOfLength(10),
     state: String? = if (ESRestTestCase.randomBoolean()) ESRestTestCase.randomAlphaOfLength(10) else null,
     include: List<StateFilter> = emptyList(),
-    safe: Boolean = false
+    isSafe: Boolean = false
 ): ChangePolicy {
-    return ChangePolicy(policyID, state, include, safe)
+    return ChangePolicy(policyID, state, include, isSafe)
 }
 
 // will only return null since we dont want to send actual notifications during integ tests

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -531,7 +531,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
             assertEquals("Attempting to rollover", getExplainManagedIndexMetaData(indexName).info?.get("message"))
         }
 
-        val newStateWithReadOnlyAction = randomState(name = stateWithReadOnlyAction.name,actions = listOf(actionConfig.copy(minDocs = 5)))
+        val newStateWithReadOnlyAction = randomState(name = stateWithReadOnlyAction.name, actions = listOf(actionConfig.copy(minDocs = 5)))
         val newRandomPolicy = randomPolicy(states = listOf(newStateWithReadOnlyAction))
         val newPolicy = createPolicy(newRandomPolicy)
         val changePolicy = ChangePolicy(newPolicy.id, null, emptyList(), false)

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -24,7 +24,9 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.StateFil
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Transition
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.DeleteActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.OpenActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ReadOnlyActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.RolloverActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.ActionMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StateMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomPolicy
@@ -77,9 +79,23 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         }
     }
 
+    fun `test nonexistent policy`() {
+        val changePolicy = ChangePolicy("doesnt_exist", null, emptyList(), false)
+        try {
+            val policy = randomPolicy(id = "some_id")
+            createPolicy(policy, policy.id)
+            client().makeRequest(RestRequest.Method.POST.toString(),
+                "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/other_index", emptyMap(), changePolicy.toHttpEntity())
+            fail("Excepted a failure.")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected RestStatus.", RestStatus.NOT_FOUND, e.response.restStatus())
+            assertEquals("Could not find policy=${changePolicy.policyID}", e.response.entity.content.bufferedReader().use { it.readText() })
+        }
+    }
+
     fun `test nonexistent ism config index`() {
         try {
-            val changePolicy = ChangePolicy("some_id", null, emptyList())
+            val changePolicy = ChangePolicy("some_id", null, emptyList(), false)
             client().makeRequest(RestRequest.Method.POST.toString(),
                     "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/other_index", emptyMap(), changePolicy.toHttpEntity())
             fail("Excepted a failure.")
@@ -93,7 +109,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
                             "type" to "index_not_found_exception",
                             "index_uuid" to "_na_",
                             "index" to ".opendistro-ism-config",
-                            "resource.type" to "index_or_alias",
+                            "resource.type" to "index_expression",
                             "resource.id" to ".opendistro-ism-config",
                             "reason" to "no such index [.opendistro-ism-config]"
                         )
@@ -101,7 +117,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
                     "type" to "index_not_found_exception",
                     "index_uuid" to "_na_",
                     "index" to ".opendistro-ism-config",
-                    "resource.type" to "index_or_alias",
+                    "resource.type" to "index_expression",
                     "resource.id" to ".opendistro-ism-config",
                     "reason" to "no such index [.opendistro-ism-config]"
                 ),
@@ -113,7 +129,8 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
 
     fun `test nonexistent index`() {
         try {
-            val changePolicy = ChangePolicy("some_id", null, emptyList())
+            val policy = createRandomPolicy()
+            val changePolicy = ChangePolicy(policy.id, null, emptyList(), false)
             client().makeRequest(RestRequest.Method.POST.toString(),
                     "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/this_does_not_exist", emptyMap(), changePolicy.toHttpEntity())
             fail("Excepted a failure.")
@@ -147,8 +164,8 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
 
     fun `test index not being managed`() {
         // Create a random policy to init .opendistro-ism-config index
-        createRandomPolicy()
-        val changePolicy = ChangePolicy("some_id", null, emptyList())
+        val policy = createRandomPolicy()
+        val changePolicy = ChangePolicy(policy.id, null, emptyList(), false)
         val response = client().makeRequest(RestRequest.Method.POST.toString(),
                 "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/movies", emptyMap(), changePolicy.toHttpEntity())
         val expectedResponse = mapOf(
@@ -177,7 +194,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         assertEquals("Policy id does not match", policy.id, managedIndexConfig.policyID)
 
         // if we try to change policy now, it'll have no ManagedIndexMetaData yet and should succeed
-        val changePolicy = ChangePolicy(newPolicy.id, null, emptyList())
+        val changePolicy = ChangePolicy(newPolicy.id, null, emptyList(), false)
         val response = client().makeRequest(RestRequest.Method.POST.toString(),
                 "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/$index", emptyMap(), changePolicy.toHttpEntity())
 
@@ -212,7 +229,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         assertEquals("Policy id does not match", policy.id, managedIndexConfig.policyID)
 
         // if we try to change policy now, it'll have no ManagedIndexMetaData yet and should go through
-        val changePolicy = ChangePolicy(newPolicy.id, null, emptyList())
+        val changePolicy = ChangePolicy(newPolicy.id, null, emptyList(), false)
         val response = client().makeRequest(RestRequest.Method.POST.toString(),
                 "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/$index,movi*", emptyMap(), changePolicy.toHttpEntity())
         val expectedResponse = mapOf(
@@ -250,11 +267,15 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         // Creates a policy that has one state with one action (sets index to read only)
         val stateWithReadOnlyAction = randomState(actions = listOf(ReadOnlyActionConfig(index = 0)))
         val randomPolicy = randomPolicy(states = listOf(stateWithReadOnlyAction))
-        val policy = createPolicy(randomPolicy, refresh = true)
+        val policy = createPolicy(randomPolicy)
 
         // Creates new policy that has two states, same as before except a second state with a delete action and a transition from readonly to delete states
+        // we will also add a new action to readonly state otherwise an immediate change policy is triggered
         val stateWithDeleteAction = randomState(actions = listOf(DeleteActionConfig(index = 0)))
-        val updatedStateWithReadOnlyAction = stateWithReadOnlyAction.copy(transitions = listOf(Transition(stateWithDeleteAction.name, null)))
+        val updatedStateWithReadOnlyAction = stateWithReadOnlyAction.copy(
+            actions = listOf(stateWithReadOnlyAction.actions.first(), OpenActionConfig(index = 1)),
+            transitions = listOf(Transition(stateWithDeleteAction.name, null))
+        )
         val newPolicy = createPolicy(randomPolicy(states = listOf(updatedStateWithReadOnlyAction, stateWithDeleteAction)), "new_policy", true)
         val indexName = "${testIndexName}_mouse"
         val (index) = createIndex(indexName, policy.id)
@@ -299,7 +320,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
                 )
             ), explainResponseMap, false)
 
-        val changePolicy = ChangePolicy(newPolicy.id, null, emptyList())
+        val changePolicy = ChangePolicy(newPolicy.id, null, emptyList(), false)
         val response = client().makeRequest(RestRequest.Method.POST.toString(),
                 "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/$index", emptyMap(), changePolicy.toHttpEntity())
         val expectedResponse = mapOf(
@@ -410,7 +431,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         waitFor { assertEquals(policy.id, getExplainManagedIndexMetaData(secondIndex).policyID) }
 
         val newPolicy = createRandomPolicy()
-        val changePolicy = ChangePolicy(newPolicy.id, null, listOf(StateFilter(state = firstState.name)))
+        val changePolicy = ChangePolicy(newPolicy.id, null, listOf(StateFilter(state = firstState.name)), false)
         val response = client().makeRequest(RestRequest.Method.POST.toString(),
                 "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/$firstIndex,$secondIndex", emptyMap(), changePolicy.toHttpEntity())
         val expectedResponse = mapOf(
@@ -445,7 +466,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         assertEquals("Policy id does not match", policy.id, managedIndexConfig.policyID)
 
         // if we try to change policy now, it'll have no ManagedIndexMetaData yet and should succeed
-        val changePolicy = ChangePolicy(newPolicy.id, "some_other_state", emptyList())
+        val changePolicy = ChangePolicy(newPolicy.id, "some_other_state", emptyList(), false)
         val response = client().makeRequest(RestRequest.Method.POST.toString(),
                 "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/$index", emptyMap(), changePolicy.toHttpEntity())
 
@@ -479,5 +500,67 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
                             assertStateEquals(StateMetaData("some_other_state", Instant.now().toEpochMilli()), stateMetaDataMap)
                 )
             ), getExplainMap(index), false)
+    }
+
+    fun `test allowing change policy to happen in middle of state if same state structure`() {
+        // Creates a policy that has one state with rollover
+        val actionConfig = RolloverActionConfig(index = 0, minDocs = 100_000_000, minAge = null, minSize = null)
+        val stateWithReadOnlyAction = randomState(actions = listOf(actionConfig))
+        val randomPolicy = randomPolicy(states = listOf(stateWithReadOnlyAction))
+        val policy = createPolicy(randomPolicy)
+        val indexName = "${testIndexName}_safe-1"
+        val (index) = createIndex(indexName, policy.id, "some_alias")
+
+        val managedIndexConfig = getExistingManagedIndexConfig(index)
+
+        // Change the start time so the job will trigger in 2 seconds and init policy
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policy.id, getExplainManagedIndexMetaData(index).policyID) }
+
+        // We should expect the explain API to show an initialized ManagedIndexMetaData with the default state from the initial policy
+        waitFor { assertEquals(policy.defaultState, getExplainManagedIndexMetaData(indexName).stateMetaData?.name) }
+
+        // add 10 documents which is not enough to trigger the 100 million rollover condition
+        insertSampleData(indexName, docCount = 10)
+
+        // Change the start time so the job will execute the rollover action
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        // verify we are in rollover and have not completed it yet
+        waitFor {
+            assertEquals(ActionConfig.ActionType.ROLLOVER.type, getExplainManagedIndexMetaData(indexName).actionMetaData?.name)
+            assertEquals("Attempting to rollover", getExplainManagedIndexMetaData(indexName).info?.get("message"))
+        }
+
+        val newStateWithReadOnlyAction = randomState(name = stateWithReadOnlyAction.name,actions = listOf(actionConfig.copy(minDocs = 5)))
+        val newRandomPolicy = randomPolicy(states = listOf(newStateWithReadOnlyAction))
+        val newPolicy = createPolicy(newRandomPolicy)
+        val changePolicy = ChangePolicy(newPolicy.id, null, emptyList(), false)
+        val response = client().makeRequest(RestRequest.Method.POST.toString(),
+            "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/$index", emptyMap(), changePolicy.toHttpEntity())
+        val expectedResponse = mapOf(
+            FAILURES to false,
+            FAILED_INDICES to emptyList<Any>(),
+            UPDATED_INDICES to 1
+        )
+        assertAffectedIndicesResponseIsEqual(expectedResponse, response.asMap())
+
+        // the change policy REST API should of set safe to true as the policies have the same state/actions
+        waitFor { assertEquals(true, getManagedIndexConfig(indexName)?.changePolicy?.safe) }
+
+        // speed up to next execution where we should swap the policy even while in the middle of the
+        // rollover action and fix our minDocs being too high
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor {
+            assertNull(getManagedIndexConfig(indexName)?.changePolicy)
+            assertEquals(newPolicy.id, getManagedIndexConfig(indexName)?.policyID)
+            assertEquals(newPolicy.id, getExplainManagedIndexMetaData(indexName).policyID)
+        }
+
+        // speed up to next execution where we should now execute with the updated policy
+        // which should now actually rollover because 5 docs is less than 10 docs
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor { assertEquals("Rolled over index", getExplainManagedIndexMetaData(indexName).info?.get("message")) }
     }
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
@@ -222,7 +222,7 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
         val indexName = "${testIndexName}_drewberry"
         val policyID = "${testIndexName}_policy_1"
         val policy = randomPolicy(states = listOf(randomState(actions = listOf(randomForceMergeActionConfig(maxNumSegments = 1)))))
-        createPolicy(policy, policyId = policyID, refresh = true)
+        createPolicy(policy, policyId = policyID)
         createIndex(indexName, policyID)
 
         val managedIndexConfig = getExistingManagedIndexConfig(indexName)

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -65,7 +65,7 @@ class ManagedIndexUtilsTests : ESTestCase() {
         val uuid = randomAlphaOfLength(10)
         val policyID = randomAlphaOfLength(10)
         val sweptManagedIndexConfig = SweptManagedIndexConfig(index = index, uuid = uuid, policyID = policyID,
-                primaryTerm = 1, seqNo = 1, changePolicy = randomChangePolicy(policyID = policyID))
+                primaryTerm = 1, seqNo = 1, changePolicy = randomChangePolicy(policyID = policyID), policy = null)
         val updateRequest = updateManagedIndexRequest(sweptManagedIndexConfig)
 
         assertNotNull("UpdateRequest not created", updateRequest)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If a user uses the change policy API to try to change policy on an index, we will compare the new policy with the current policy to and see if we consider it "safe" to do an immediate change on the next execution rather than waiting until the end of the current state.

We want to give this option because of situations like a user putting the incorrect rollover conditions and the managed index never reaching the end of the state, or a user putting incorrect configuration options like in a notification and it always failing (where doing retry just makes it fail again). They need a way to safely change the policy during these situations.

So we deem a it "safe" if the two policies have the same current state name w/ the same actions in the same order (this is so we do not break the actionIndex property in the ManagedIndexMetaData) and a state_name to transition to on the ChangePolicy does not exist (we do not want the user accidentally transition to a different state). This lets users easily change the actual configuration properties of each action in a state and having the change go through on the next execution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
