### PR TITLE
Adds AllowList functionality

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementPlugin.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementPlugin.kt
@@ -118,7 +118,7 @@ internal class IndexStateManagementPlugin : JobSchedulerExtension, ActionPlugin,
         nodesInCluster: Supplier<DiscoveryNodes>
     ): List<RestHandler> {
         return listOf(
-            RestIndexPolicyAction(settings, restController, indexStateManagementIndices),
+            RestIndexPolicyAction(settings, restController, clusterService, indexStateManagementIndices),
             RestGetPolicyAction(settings, restController),
             RestDeletePolicyAction(settings, restController),
             RestExplainAction(settings, restController),
@@ -173,7 +173,8 @@ internal class IndexStateManagementPlugin : JobSchedulerExtension, ActionPlugin,
             ManagedIndexSettings.HISTORY_MAX_DOCS,
             ManagedIndexSettings.HISTORY_INDEX_MAX_AGE,
             ManagedIndexSettings.HISTORY_ROLLOVER_CHECK_PERIOD,
-            ManagedIndexSettings.HISTORY_RETENTION_PERIOD
+            ManagedIndexSettings.HISTORY_RETENTION_PERIOD,
+            ManagedIndexSettings.ALLOW_LIST
         )
     }
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
@@ -34,6 +34,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedi
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StateMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings.Companion.ALLOW_LIST
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings.Companion.ALLOW_LIST_NONE
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings.Companion.DEFAULT_ISM_ENABLED
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings.Companion.DEFAULT_JOB_INTERVAL
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings.Companion.INDEX_STATE_MANAGEMENT_ENABLED
@@ -119,9 +120,8 @@ object ManagedIndexRunner : ScheduledJobRunner,
     private val updateMetaDataRetryPolicy = BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(250), 3)
     @Suppress("MagicNumber")
     private val errorNotificationRetryPolicy = BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(250), 3)
-    @Suppress("MagicNumber")
     private var jobInterval: Int = DEFAULT_JOB_INTERVAL
-    private var allowList: List<String> = emptyList()
+    private var allowList: List<String> = ALLOW_LIST_NONE
 
     fun registerClusterService(clusterService: ClusterService): ManagedIndexRunner {
         this.clusterService = clusterService

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
@@ -33,6 +33,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedi
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.PolicyRetryInfoMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StateMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings.Companion.ALLOW_LIST
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings.Companion.DEFAULT_ISM_ENABLED
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings.Companion.DEFAULT_JOB_INTERVAL
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings.Companion.INDEX_STATE_MANAGEMENT_ENABLED
@@ -46,6 +47,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.getComple
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.hasDifferentJobInterval
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.hasTimedOut
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.hasVersionConflict
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.isAllowed
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.isFailed
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.isSafeToChange
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.isSuccessfulDelete
@@ -119,6 +121,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
     private val errorNotificationRetryPolicy = BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(250), 3)
     @Suppress("MagicNumber")
     private var jobInterval: Int = DEFAULT_JOB_INTERVAL
+    private var allowList: List<String> = emptyList()
 
     fun registerClusterService(clusterService: ClusterService): ManagedIndexRunner {
         this.clusterService = clusterService
@@ -155,6 +158,11 @@ object ManagedIndexRunner : ScheduledJobRunner,
         indexStateManagementEnabled = INDEX_STATE_MANAGEMENT_ENABLED.get(settings)
         clusterService.clusterSettings.addSettingsUpdateConsumer(INDEX_STATE_MANAGEMENT_ENABLED) {
             indexStateManagementEnabled = it
+        }
+
+        allowList = ALLOW_LIST.get(settings)
+        clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) {
+            allowList = it
         }
         return this
     }
@@ -256,6 +264,15 @@ object ManagedIndexRunner : ScheduledJobRunner,
 
         if (managedIndexMetaData.stepMetaData?.stepStatus == Step.StepStatus.STARTING) {
             val info = mapOf("message" to "Previous action was not able to update IndexMetaData.")
+            val updated = updateManagedIndexMetaData(managedIndexMetaData.copy(policyRetryInfo = PolicyRetryInfoMetaData(true, 0), info = info))
+            if (updated) disableManagedIndexConfig(managedIndexConfig)
+            return
+        }
+
+        // If this action is not allowed and the step to be executed is the first step in the action then we will fail
+        // as this action has been removed from the AllowList, but if its not the first step we will let it finish as it's already inflight
+        if (action?.isAllowed(allowList) == false && action.isFirstStep(step?.name)) {
+            val info = mapOf("message" to "Attempted to execute action=${action.type.type} which is not allowed.")
             val updated = updateManagedIndexMetaData(managedIndexMetaData.copy(policyRetryInfo = PolicyRetryInfoMetaData(true, 0), info = info))
             if (updated) disableManagedIndexConfig(managedIndexConfig)
             return

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/Action.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/Action.kt
@@ -27,4 +27,6 @@ abstract class Action(val type: ActionType, val config: ActionConfig, val manage
     abstract fun getStepToExecute(): Step
 
     fun isLastStep(stepName: String): Boolean = getSteps().last().name == stepName
+
+    fun isFirstStep(stepName: String?): Boolean = getSteps().first().name == stepName
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/ManagedIndexMetaData.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/ManagedIndexMetaData.kt
@@ -109,7 +109,7 @@ data class ManagedIndexMetaData(
             builder.endObject()
         }
 
-        if (policyRetryInfo != null && !transitionToExists) {
+        if (policyRetryInfo != null) {
             builder.startObject(PolicyRetryInfoMetaData.RETRY_INFO)
             policyRetryInfo.toXContent(builder, params)
             builder.endObject()

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestIndexPolicyAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestIndexPolicyAction.kt
@@ -20,6 +20,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateMana
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateManagementPlugin.Companion.POLICY_BASE_URI
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy.Companion.POLICY_TYPE
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings.Companion.ALLOW_LIST
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.IF_PRIMARY_TERM
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.IF_SEQ_NO
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.REFRESH
@@ -27,6 +28,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.util._ID
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util._PRIMARY_TERM
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util._SEQ_NO
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util._VERSION
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.getDisallowedActions
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.action.ActionListener
 import org.elasticsearch.action.DocWriteRequest
@@ -35,6 +37,7 @@ import org.elasticsearch.action.index.IndexRequest
 import org.elasticsearch.action.index.IndexResponse
 import org.elasticsearch.action.support.WriteRequest
 import org.elasticsearch.client.node.NodeClient
+import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.index.seqno.SequenceNumbers
@@ -54,13 +57,16 @@ import java.time.Instant
 class RestIndexPolicyAction(
     settings: Settings,
     controller: RestController,
+    val clusterService: ClusterService,
     indexStateManagementIndices: IndexStateManagementIndices
 ) : BaseRestHandler(settings) {
 
     private val log = LogManager.getLogger(javaClass)
     private var ismIndices = indexStateManagementIndices
+    @Volatile private var allowList = ALLOW_LIST.get(settings)
 
     init {
+        clusterService.clusterSettings.addSettingsUpdateConsumer(ALLOW_LIST) { allowList = it }
         controller.registerHandler(PUT, POLICY_BASE_URI, this)
         controller.registerHandler(PUT, "$POLICY_BASE_URI/{policyID}", this)
     }
@@ -78,6 +84,17 @@ class RestIndexPolicyAction(
 
         val xcp = request.contentParser()
         val policy = Policy.parseWithType(xcp = xcp, id = id).copy(lastUpdatedTime = Instant.now())
+        val disallowedActions = policy.getDisallowedActions(allowList)
+        if (disallowedActions.isNotEmpty()) {
+            return RestChannelConsumer { channel ->
+                channel.sendResponse(
+                    BytesRestResponse(
+                        RestStatus.FORBIDDEN,
+                        "You have actions that are not allowed in your policy $disallowedActions"
+                    )
+                )
+            }
+        }
         val seqNo = request.paramAsLong(IF_SEQ_NO, SequenceNumbers.UNASSIGNED_SEQ_NO)
         val primaryTerm = request.paramAsLong(IF_PRIMARY_TERM, SequenceNumbers.UNASSIGNED_PRIMARY_TERM)
         val refreshPolicy = if (request.hasParam(REFRESH)) {

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/settings/ManagedIndexSettings.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/settings/ManagedIndexSettings.kt
@@ -15,9 +15,11 @@
 
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.settings
 
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ActionConfig
 import org.elasticsearch.common.settings.Setting
 import org.elasticsearch.common.unit.TimeValue
 import java.util.concurrent.TimeUnit
+import java.util.function.Function
 
 class ManagedIndexSettings {
     companion object {
@@ -106,6 +108,14 @@ class ManagedIndexSettings {
         val HISTORY_RETENTION_PERIOD = Setting.positiveTimeSetting(
             "opendistro.index_state_management.history.rollover_retention_period",
             TimeValue(30, TimeUnit.DAYS),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        )
+
+        val ALLOW_LIST = Setting.listSetting(
+            "opendistro.index_state_management.allow_list",
+            ActionConfig.ActionType.values().toList().map { it.type },
+            Function.identity(),
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         )

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/settings/ManagedIndexSettings.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/settings/ManagedIndexSettings.kt
@@ -25,6 +25,8 @@ class ManagedIndexSettings {
     companion object {
         const val DEFAULT_ISM_ENABLED = true
         const val DEFAULT_JOB_INTERVAL = 5
+        val ALLOW_LIST_ALL = ActionConfig.ActionType.values().toList().map { it.type }
+        val ALLOW_LIST_NONE = emptyList<String>()
 
         val INDEX_STATE_MANAGEMENT_ENABLED = Setting.boolSetting(
             "opendistro.index_state_management.enabled",
@@ -114,7 +116,7 @@ class ManagedIndexSettings {
 
         val ALLOW_LIST = Setting.listSetting(
             "opendistro.index_state_management.allow_list",
-            ActionConfig.ActionType.values().toList().map { it.type },
+            ALLOW_LIST_ALL,
             Function.identity(),
             Setting.Property.NodeScope,
             Setting.Property.Dynamic

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -486,3 +486,24 @@ fun Policy.isSafeToChange(stateName: String?, newPolicy: Policy, changePolicy: C
 
     return true
 }
+
+/**
+ * Disallowed actions are ones that are not specified in the [ManagedIndexSettings.ALLOW_LIST] setting.
+ */
+fun Policy.getDisallowedActions(allowList: List<String>): List<String> {
+    val allowListSet = allowList.toSet()
+    val disallowedActions = mutableListOf<String>()
+    this.states.forEach { state ->
+        state.actions.forEach { actionConfig ->
+            if (!allowListSet.contains(actionConfig.type.type)) {
+                disallowedActions.add(actionConfig.type.type)
+            }
+        }
+    }
+    return disallowedActions.distinct()
+}
+
+/**
+ * Allowed actions are ones that are specified in the [ManagedIndexSettings.ALLOW_LIST] setting.
+ */
+fun Action.isAllowed(allowList: List<String>): Boolean = allowList.contains(this.type.type)

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -204,11 +204,12 @@ abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
         return indexSettings[index]!!["settings"]!![ManagedIndexSettings.POLICY_ID.key] as? String
     }
 
-    protected fun updateClusterSetting(key: String, value: String) {
+    protected fun updateClusterSetting(key: String, value: String, escapeValue: Boolean = true) {
+        val formattedValue = if (escapeValue) "\"value\"" else value
         val request = """
             {
                 "persistent": {
-                    "$key": "$value"
+                    "$key": $formattedValue
                 }
             }
         """.trimIndent()

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -205,7 +205,7 @@ abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
     }
 
     protected fun updateClusterSetting(key: String, value: String, escapeValue: Boolean = true) {
-        val formattedValue = if (escapeValue) "\"value\"" else value
+        val formattedValue = if (escapeValue) "\"$value\"" else value
         val request = """
             {
                 "persistent": {

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/runner/ManagedIndexRunnerIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/runner/ManagedIndexRunnerIT.kt
@@ -113,9 +113,9 @@ class ManagedIndexRunnerIT : IndexStateManagementRestTestCase() {
     fun `test allow list fails execution`() {
         val indexName = "allow_list_index"
 
-        val firstState = randomState(name ="first_state", actions = listOf(randomReadOnlyActionConfig()),
+        val firstState = randomState(name = "first_state", actions = listOf(randomReadOnlyActionConfig()),
             transitions = listOf(randomTransition(stateName = "second_state", conditions = null)))
-        val secondState = randomState(name ="second_state", actions = listOf(randomReadWriteActionConfig()),
+        val secondState = randomState(name = "second_state", actions = listOf(randomReadWriteActionConfig()),
             transitions = listOf(randomTransition(stateName = "first_state", conditions = null)))
         val randomPolicy = randomPolicy(id = "allow_policy", states = listOf(firstState, secondState))
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds AllowList functionality
By default all actions are allowed
If PUT Policy API is called using an action not allowed then it will fail with 403 Forbidden
If AllowList is updated after a policy is created and a managed index using that policy tries to execute an action that is not allowed then it will fail w/ reason stating the action is not allowed

Chose AllowList over DenyList because forgetting to add an action to an AllowList is safer than forgetting to add an action to DenyList.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
