### PR TITLE
Removes transitive dependencies for notification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,20 +64,17 @@ allOpen {
 
 configurations {
     ktlint
+    testCompile {
+        exclude group: "commons-logging", module: "commons-logging"
+        exclude group: "commons-codec", module: "commons-codec"
+        exclude group: "org.apache.httpcomponents", module: "httpclient"
+        exclude group: "org.apache.httpcomponents", module: "httpcore"
+    }
 }
 
 detekt {
     config = files("detekt.yml")
     buildUponDefaultConfig = true
-}
-
-configurations.all {
-    if (it.state != Configuration.State.UNRESOLVED) return
-    resolutionStrategy {
-        force "commons-logging:commons-logging:${versions.commonslogging}"
-        force "org.apache.httpcomponents:httpcore:${versions.httpcore}"
-        force "commons-codec:commons-codec:${versions.commonscodec}"
-    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -88,11 +88,6 @@ dependencies {
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'
     compile "org.jetbrains:annotations:13.0"
     compile "com.amazon.opendistroforelasticsearch:notification:1.2.0.0"
-    // alerting-notification transitive dependencies
-    compile "org.apache.httpcomponents:httpcore:4.4.5"
-    compile "org.apache.httpcomponents:httpclient:4.5.8"
-    compile "commons-logging:commons-logging:1.2"
-    compile "commons-codec:commons-codec:1.11"
 
     testCompile "org.elasticsearch.test:framework:${es_version}"
     testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"


### PR DESCRIPTION
*Issue #, if available:*
We had included transitive dependencies for the notification subproject because elasticsearch does not include transitive dependencies for our plugins. The PR that publishes notification to maven was updated to include its own dependencies using shadow jars. This is also to ensure there are no conflicts between our notification jar/dependencies and other plugins.

Now that the published notification jars has the dependencies itself we can remove these, otherwise we get jar hell when installing the plugin.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
