### PR TITLE
Remove excludes in test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,12 +64,6 @@ allOpen {
 
 configurations {
     ktlint
-    testCompile {
-        exclude group: "commons-logging", module: "commons-logging"
-        exclude group: "commons-codec", module: "commons-codec"
-        exclude group: "org.apache.httpcomponents", module: "httpclient"
-        exclude group: "org.apache.httpcomponents", module: "httpcore"
-    }
 }
 
 detekt {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Issue with class type mismatch between repackaged jars in notification and dependencies pulled in by elasticsearch client. This shouldn't be needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
