### PR TITLE
Create Build and Test Workflow for opendistro-1.2 branch

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -1,0 +1,38 @@
+name: Test and Build Workflow
+# This workflow is triggered on pull requests to master or a opendistro release branch
+on:
+  pull_request:
+    branches:
+      - master
+      - opendistro-*
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [12]
+    # Job name
+    name: Build Index Management with JDK ${{ matrix.java }}
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+      # This step uses the checkout Github action: https://github.com/actions/checkout
+      - name: Checkout Branch
+        uses: actions/checkout@v1
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build with Gradle
+        run: ./gradlew build
+      - name: Create Artifact Path
+        run: |
+          mkdir -p index-management-artifacts
+          cp ./build/distributions/*.zip index-management-artifacts
+      # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: index-management-plugin
+          path: index-management-artifacts


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I'm suspecting that the workflow file needs to be present on each branch that will be running it since a recent PR I submitted did not trigger the workflow. Backporting the workflow commit from master to this branch to see if this is the case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
