### PR TITLE
Index Management CI/CD

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,41 @@
+name: Build and Release Index Management
+on:
+  push:
+    branches:
+      - opendistro-*
+
+jobs:
+  Release-Index-Management:
+    strategy:
+      matrix:
+        java: [12]
+
+    name: Build and Release Index Management
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Index Management
+        uses: actions/checkout@v1
+        
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+          
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+      
+      - name: Run build
+        run: |
+          ./gradlew build buildDeb buildRpm --console=plain -Dbuild.snapshot=false
+          artifact=`ls build/distributions/*.zip`
+          rpm_artifact=`ls build/distributions/*.rpm`
+          deb_artifact=`ls build/distributions/*.deb`
+          aws s3 cp $artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/elasticsearch-plugins/opendistro-index-management/
+          aws s3 cp $rpm_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/rpms/opendistro-index-management/
+          aws s3 cp $deb_artifact s3://artifacts.opendistroforelasticsearch.amazon.com/downloads/debs/opendistro-index-management/
+          aws cloudfront create-invalidation --distribution-id E1VG5HMIWI4SA2 --paths "/*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
   Build-Index-Management:
     strategy:
       matrix:
-        java: [13]
+        java: [12]
 
     name: Build and Test Index Management
     runs-on: macos-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,7 @@ name: Build and Test Index Management
 on:
   push:
     branches:
+      - master
       - opendistro-*
 
 jobs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
         java: [12]
 
     name: Build and Test Index Management
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Index Management

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,6 @@ name: Build and Test Index Management
 on:
   push:
     branches:
-      - master
       - opendistro-*
 
 jobs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,6 +24,37 @@ jobs:
           java-version: ${{ matrix.java }}
       
       - name: Run build
+        run: ./gradlew build
+          
+      - name: Create Plugin Zip for Testing
+        run: ./gradlew build --console=plain -Dbuild.snapshot=false
+      
+      - name: Pull and Run Docker
         run: |
-          ./gradlew build
-          ls -ltr build/distributions/
+          plugin=`ls build/distributions/*.zip`
+          version=`echo $plugin|awk -F- '{print $2}'| cut -d. -f 1-3`
+          plugin_version=`echo $plugin|awk -F- '{print $2}'| cut -d. -f 1-4`
+          echo $version
+          cd ..
+          
+          if docker pull opendistroforelasticsearch/opendistroforelasticsearch:$version
+          then
+            echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$version" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security; fi" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_index_management ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_sql; fi" >> Dockerfile
+            echo "ADD index-management/build/distributions/opendistro_index_management-$plugin_version.zip /tmp/" >> Dockerfile
+            echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:/tmp/opendistro_index_management-$plugin_version.zip" >> Dockerfile
+            
+            docker build -t odfe-index-management:test .
+          fi
+          
+      - name: Run Docker Image
+        run: |
+          cd ..
+          docker run -p 9200:9200 -d -p 9600:9600 -e "discovery.type=single-node" odfe-index-management:test
+          sleep 15
+          curl -XGET http://localhost:9200/_cat/plugins
+          
+      - name: Run Index-Management Test
+        run: |
+          ./gradlew integTest -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,7 @@ jobs:
           then
             echo "FROM opendistroforelasticsearch/opendistroforelasticsearch:$version" >> Dockerfile
             echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_security ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_security; fi" >> Dockerfile
-            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_index_management ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_sql; fi" >> Dockerfile
+            echo "RUN if [ -d /usr/share/elasticsearch/plugins/opendistro_index_management ]; then /usr/share/elasticsearch/bin/elasticsearch-plugin remove opendistro_index_management; fi" >> Dockerfile
             echo "ADD index-management/build/distributions/opendistro_index_management-$plugin_version.zip /tmp/" >> Dockerfile
             echo "RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install --batch file:/tmp/opendistro_index_management-$plugin_version.zip" >> Dockerfile
             

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,29 @@
+name: Build and Test Index Management
+on:
+  push:
+    branches:
+      - master
+      - opendistro-*
+
+jobs:
+  Build-Index-Management:
+    strategy:
+      matrix:
+        java: [13]
+
+    name: Build and Test Index Management
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Index Management
+        uses: actions/checkout@v1
+        
+      - name: Setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      
+      - name: Run build
+        run: |
+          ./gradlew build
+          ls -ltr build/distributions/


### PR DESCRIPTION
###CI.yml

This job will trigger on every code checkin in master and opendistro branches which then will build the index management plugin and run integration tests against the respective version of opendistro staging docker image.
Before running the test the job will first remove index management plugin, if available, then it will re-install the built plugin.

###CD.yml
This job will trigger whenever a code checkin is made on an opendistro branch or a new opendistro branch is cut. It will build all the artifacts and then upload to respective S3 paths.

Assumption: the new opendistro branch is cut only when the plugin is ready to be released.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
