### PR TITLE
fix some build issues in OD 0.10

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [13]
+        java: [12]
     # Job name
     name: Build Index Management with JDK ${{ matrix.java }}
     # This job runs on Linux

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -1,0 +1,38 @@
+name: Test and Build Workflow
+# This workflow is triggered on pull requests to master or a opendistro release branch
+on:
+  pull_request:
+    branches:
+      - master
+      - opendistro-*
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [13]
+    # Job name
+    name: Build Index Management with JDK ${{ matrix.java }}
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+      # This step uses the checkout Github action: https://github.com/actions/checkout
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build with Gradle
+        run: ./gradlew Build
+      - name: Create Artifact Path
+        run: |
+          mkdir -p index-management-artifacts
+          cp ./build/distributions/*.zip index-management-artifacts
+      # This step uses the upload-artifact Github action: https://github.com/actions/upload-artifact
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: index-management-plugin
+          path: index-management-artifacts

--- a/build-tools/esplugin-coverage.gradle
+++ b/build-tools/esplugin-coverage.gradle
@@ -53,6 +53,10 @@ task dummyIntegTest(type: Test) {
     }
 }
 
+unitTest {
+    jvmArg dummyTest.jacoco.getAsJvmArg()
+}
+
 integTestCluster {
     jvmArgs += " ${dummyIntegTest.jacoco.getAsJvmArg()}"
     systemProperty 'com.sun.management.jmxremote', "true"

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,6 @@ buildscript {
     repositories {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
-        // TODO: remove mavenLocal once notification is published to maven
-        mavenLocal()
     }
 
     dependencies {
@@ -78,7 +76,7 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'
     compile "org.jetbrains:annotations:13.0"
-    compile "com.amazon.opendistroforelasticsearch:notification:0.10.0.0"
+    compile "com.amazon.opendistroforelasticsearch:notification:0.10.0.1"
 
     testCompile "org.elasticsearch.test:framework:${es_version}"
     testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ detekt {
 
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"
-    compileOnly "com.amazon.opendistroforelasticsearch:opendistro-job-scheduler-spi:0.10.0.1"
+    compileOnly "com.amazon.opendistroforelasticsearch:opendistro-job-scheduler-spi:0.10.0.2"
     compile "org.jetbrains.kotlin:kotlin-stdlib:${kotlin_version}"
     compile "org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin_version}"
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/transport/action/updateindexmetadata/UpdateManagedIndexMetaDataAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/transport/action/updateindexmetadata/UpdateManagedIndexMetaDataAction.kt
@@ -19,8 +19,10 @@ import org.elasticsearch.action.Action
 import org.elasticsearch.action.support.master.AcknowledgedResponse
 import org.elasticsearch.client.ElasticsearchClient
 
-object UpdateManagedIndexMetaDataAction
-    : Action<UpdateManagedIndexMetaDataRequest, AcknowledgedResponse, UpdateManagedIndexMetaDataRequestBuilder>("cluster:admin/ism/update/managedindexmetadata") {
+object UpdateManagedIndexMetaDataAction : Action<
+    UpdateManagedIndexMetaDataRequest,
+    AcknowledgedResponse,
+    UpdateManagedIndexMetaDataRequestBuilder>("cluster:admin/ism/update/managedindexmetadata") {
     override fun newResponse(): AcknowledgedResponse {
         return AcknowledgedResponse()
     }


### PR DESCRIPTION
*Description of changes:*
1. **Fix issue with jacoco unable to execute test.**

```
Execution failed for task ':jacocoTestReport'.
> Unable to read execution data file /Users/jinsoor/ws/opensource/index-management/build/jacoco/test.exec
```

2. **Fix format issue to comply with ktlint**

```
/local/apollo/var/env/SearchServicesHome/home/jinsoor/ws/opensource/index-management/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/transport/action/updateindexmetadata/UpdateManagedIndexMetaDataAction.kt:22:40: Unexpected newline before ":"
```

build successful. Looks like we have to publish notification 0.10.0.0 into maven.
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.4.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 5m 54s
39 actionable tasks: 38 executed, 1 up-to-date
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
