### PR TITLE
Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,4 +169,6 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     args "-F", "src/**/*.kt"
 }
 
+compileKotlin { kotlinOptions.freeCompilerArgs = ['-Xjsr305=strict'] }
+
 apply from: 'build-tools/pkgbuild.gradle'

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
@@ -117,6 +117,7 @@ class WaitForForceMergeStep(
                 return statsResponse.shards.count {
                     val count = it.stats.segments?.count
                     if (count == null) {
+                        logger.warn("$indexName wait for force merge had null segments")
                         false
                     } else {
                         count > maxNumSegments

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/WaitForForceMergeStep.kt
@@ -114,7 +114,14 @@ class WaitForForceMergeStep(
             val statsResponse: IndicesStatsResponse = client.admin().indices().suspendUntil { stats(statsRequest, it) }
 
             if (statsResponse.status == RestStatus.OK) {
-                return statsResponse.shards.count { it.stats.segments.count > maxNumSegments }
+                return statsResponse.shards.count {
+                    val count = it.stats.segments?.count
+                    if (count == null) {
+                        false
+                    } else {
+                        count > maxNumSegments
+                    }
+                }
             }
 
             logger.debug("Failed to get index stats for index: [$indexName], status response: [${statsResponse.status}]")

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -71,8 +71,8 @@ class AttemptRolloverStep(
         if (indexCreationDate == -1L) {
             logger.warn("$index had an indexCreationDate=-1L, cannot use for comparison")
         }
-        val numDocs = statsResponse.primaries.docs.count
-        val indexSize = ByteSizeValue(statsResponse.primaries.docs.totalSizeInBytes)
+        val numDocs = statsResponse.primaries.docs?.count ?: 0
+        val indexSize = ByteSizeValue(statsResponse.primaries.docs?.totalSizeInBytes ?: 0)
 
         if (config.evaluateConditions(indexCreationDateInstant, numDocs, indexSize)) {
             logger.info("$index rollover conditions evaluated to true [indexCreationDate=$indexCreationDate," +

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/transition/AttemptTransitionStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/transition/AttemptTransitionStep.kt
@@ -91,8 +91,8 @@ class AttemptTransitionStep(
                     return
                 }
 
-                numDocs = statsResponse.primaries.docs.count
-                indexSize = ByteSizeValue(statsResponse.primaries.docs.totalSizeInBytes)
+                numDocs = statsResponse.primaries.docs?.count ?: 0
+                indexSize = ByteSizeValue(statsResponse.primaries.docs?.totalSizeInBytes ?: 0)
             }
 
             // Find the first transition that evaluates to true and get the state to transition to, otherwise return null if none are true

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/transition/AttemptTransitionStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/transition/AttemptTransitionStep.kt
@@ -55,24 +55,32 @@ class AttemptTransitionStep(
 
     @Suppress("TooGenericExceptionCaught")
     override suspend fun execute() {
+        val index = managedIndexMetaData.index
         try {
             if (config.transitions.isEmpty()) {
+                logger.info("$index transitions are empty, completing policy")
                 policyCompleted = true
                 stepStatus = StepStatus.COMPLETED
                 return
             }
 
+            val indexCreationDate = clusterService.state().metaData().index(index).creationDate
+            val indexCreationDateInstant = Instant.ofEpochMilli(indexCreationDate)
+            if (indexCreationDate == -1L) {
+                logger.warn("$index had an indexCreationDate=-1L, cannot use for comparison")
+            }
+            val stepStartTime = getStepStartTime()
             var numDocs: Long? = null
             var indexSize: ByteSizeValue? = null
 
             if (config.transitions.any { it.hasStatsConditions() }) {
                 val statsRequest = IndicesStatsRequest()
-                    .indices(managedIndexMetaData.index).clear().docs(true)
+                    .indices(index).clear().docs(true)
                 val statsResponse: IndicesStatsResponse = client.admin().indices().suspendUntil { stats(statsRequest, it) }
 
                 if (statsResponse.status != RestStatus.OK) {
                     logger.debug(
-                        "Failed to get index stats for index: [${managedIndexMetaData.index}], status response: [${statsResponse.status}]"
+                        "Failed to get index stats for index: [$index], status response: [${statsResponse.status}]"
                     )
 
                     stepStatus = StepStatus.FAILED
@@ -85,21 +93,23 @@ class AttemptTransitionStep(
 
                 numDocs = statsResponse.primaries.docs.count
                 indexSize = ByteSizeValue(statsResponse.primaries.docs.totalSizeInBytes)
-                // Find the first transition that evaluates to true and get the state to transition to, otherwise return null if none are true
             }
 
             // Find the first transition that evaluates to true and get the state to transition to, otherwise return null if none are true
-            stateName = config.transitions.find { it.evaluateConditions(getIndexCreationDate(), numDocs, indexSize, getStepStartTime()) }?.stateName
-            val message = if (stateName == null) {
-                stepStatus = StepStatus.CONDITION_NOT_MET
-                "Attempting to transition"
-            } else {
+            stateName = config.transitions.find { it.evaluateConditions(indexCreationDateInstant, numDocs, indexSize, stepStartTime) }?.stateName
+            val message: String
+            if (stateName != null) {
+                logger.info("$index transition conditions evaluated to true [indexCreationDate=$indexCreationDate," +
+                        " numDocs=$numDocs, indexSize=${indexSize?.bytes},stepStartTime=${stepStartTime.toEpochMilli()}]")
                 stepStatus = StepStatus.COMPLETED
-                "Transitioning to $stateName"
+                message = "Transitioning to $stateName"
+            } else {
+                stepStatus = StepStatus.CONDITION_NOT_MET
+                message = "Attempting to transition"
             }
             info = mapOf("message" to message)
         } catch (e: Exception) {
-            logger.error("Failed to transition index [index=${managedIndexMetaData.index}]", e)
+            logger.error("Failed to transition index [index=$index]", e)
             stepStatus = StepStatus.FAILED
             val mutableInfo = mutableMapOf("message" to "Failed to transition index")
             val errorMessage = e.message
@@ -107,9 +117,6 @@ class AttemptTransitionStep(
             info = mutableInfo.toMap()
         }
     }
-
-    private fun getIndexCreationDate(): Instant =
-        Instant.ofEpochMilli(clusterService.state().metaData().index(managedIndexMetaData.index).creationDate)
 
     override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData {
         return currentMetaData.copy(

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -193,7 +193,9 @@ fun Transition.evaluateConditions(
     }
 
     if (this.conditions.indexAge != null) {
-        val elapsedTime = Instant.now().toEpochMilli() - indexCreationDate.toEpochMilli()
+        val indexCreationDateMilli = indexCreationDate.toEpochMilli()
+        if (indexCreationDateMilli == -1L) return false // transitions cannot currently be ORd like rollover, so we must return here
+        val elapsedTime = Instant.now().toEpochMilli() - indexCreationDateMilli
         return this.conditions.indexAge.millis <= elapsedTime
     }
 
@@ -230,8 +232,11 @@ fun RolloverActionConfig.evaluateConditions(
     }
 
     if (this.minAge != null) {
-        val elapsedTime = Instant.now().toEpochMilli() - indexCreationDate.toEpochMilli()
-        if (this.minAge.millis <= elapsedTime) return true
+        val indexCreationDateMilli = indexCreationDate.toEpochMilli()
+        if (indexCreationDateMilli != -1L) {
+            val elapsedTime = Instant.now().toEpochMilli() - indexCreationDateMilli
+            if (this.minAge.millis <= elapsedTime) return true
+        }
     }
 
     if (this.minSize != null) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* The index creation_date defaults to -1L if there is none. I'm not sure if this ever actually happens, but adding logic/tests to treat it accordingly.
* Adds tests around the evaluate methods
* Adds logs before transition/rollover execution with the values when they evaluate to true.
* Added kotlin compiler setting to not compile for nullable values not handled correctly w/ java interop. (Thanks Vinoo!)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
