### PR TITLE
Update test-and-build-workflow.yml

### DIFF
--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         java: [13]
     # Job name
-    name: Build Index Management with JDK ${{ matrix.java }}
+    name: Build Index Management
     # This job runs on Linux
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-and-build-workflow.yml
+++ b/.github/workflows/test-and-build-workflow.yml
@@ -8,9 +8,6 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        java: [13]
     # Job name
     name: Build Index Management
     # This job runs on Linux
@@ -20,10 +17,10 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@v2
       # This step uses the setup-java Github action: https://github.com/actions/setup-java
-      - name: Set Up JDK ${{ matrix.java }}
+      - name: Set Up JDK 13
         uses: actions/setup-java@v1
         with:
-          java-version: ${{ matrix.java }}
+          java-version: 13
       - name: Build with Gradle
         run: ./gradlew build
       - name: Create Artifact Path


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some of our PRs get stuck with required status checks, most likely because the name of the status check is used as the key and older branches will expect a JDK 13 check to pass or newer branches were expecting a JDK 12 to pass. This removes the variable from the name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
