### PR TITLE
Adds rollover conditions into info object

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -46,6 +46,7 @@ import org.elasticsearch.action.update.UpdateRequest
 import org.elasticsearch.client.Client
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.unit.ByteSizeValue
+import org.elasticsearch.common.unit.TimeValue
 import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.common.xcontent.XContentFactory
 import org.elasticsearch.index.query.BoolQueryBuilder
@@ -216,7 +217,7 @@ fun Transition.hasStatsConditions(): Boolean = this.conditions?.docCount != null
 
 @Suppress("ReturnCount")
 fun RolloverActionConfig.evaluateConditions(
-    indexCreationDate: Instant,
+    indexAgeTimeValue: TimeValue,
     numDocs: Long,
     indexSize: ByteSizeValue
 ): Boolean {
@@ -232,11 +233,7 @@ fun RolloverActionConfig.evaluateConditions(
     }
 
     if (this.minAge != null) {
-        val indexCreationDateMilli = indexCreationDate.toEpochMilli()
-        if (indexCreationDateMilli != -1L) {
-            val elapsedTime = Instant.now().toEpochMilli() - indexCreationDateMilli
-            if (this.minAge.millis <= elapsedTime) return true
-        }
+        if (this.minAge.millis <= indexAgeTimeValue.millis) return true
     }
 
     if (this.minSize != null) {

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionTimeoutIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionTimeoutIT.kt
@@ -20,6 +20,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedI
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.ActionMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.waitFor
+import org.hamcrest.collection.IsMapContaining
 import java.time.Instant
 import java.util.Locale
 
@@ -54,13 +55,11 @@ class ActionTimeoutIT : IndexStateManagementRestTestCase() {
 
         // the second execution we move into rollover action, we won't hit the timeout as this is the execution that sets the startTime
         updateManagedIndexConfigStartTime(managedIndexConfig)
-
-        val expectedInfoString = mapOf("message" to "Attempting to rollover").toString()
         waitFor {
-            assertPredicatesOnMetaData(
-                listOf(indexName to listOf(ManagedIndexMetaData.INFO to fun(info: Any?): Boolean = expectedInfoString == info.toString())),
-                getExplainMap(indexName),
-                strict = false
+            assertThat(
+                "Should be attempting to rollover",
+                getExplainManagedIndexMetaData(indexName).info,
+                IsMapContaining.hasEntry("message", "Attempting to rollover" as Any?)
             )
         }
 
@@ -122,13 +121,11 @@ class ActionTimeoutIT : IndexStateManagementRestTestCase() {
         // the third execution we move into rollover action, we should not hit the timeout yet because its the first execution of rollover
         // but there was a bug before where it would use the startTime from the previous actions metadata and immediately fail
         updateManagedIndexConfigStartTime(managedIndexConfig)
-
-        val expectedRolloverInfoString = mapOf("message" to "Attempting to rollover").toString()
         waitFor {
-            assertPredicatesOnMetaData(
-                listOf(indexName to listOf(ManagedIndexMetaData.INFO to fun(info: Any?): Boolean = expectedRolloverInfoString == info.toString())),
-                getExplainMap(indexName),
-                strict = false
+            assertThat(
+                "Should be attempting to rollover",
+                getExplainManagedIndexMetaData(indexName).info,
+                IsMapContaining.hasEntry("message", "Attempting to rollover" as Any?)
             )
         }
     }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/RolloverActionIT.kt
@@ -16,17 +16,15 @@
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.action
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateManagementRestTestCase
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.makeRequest
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.State
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.RolloverActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomErrorNotification
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.waitFor
-import org.apache.http.entity.ContentType
-import org.apache.http.entity.StringEntity
 import org.elasticsearch.common.unit.ByteSizeUnit
 import org.elasticsearch.common.unit.ByteSizeValue
-import org.elasticsearch.rest.RestRequest
+import org.elasticsearch.common.unit.TimeValue
+import org.hamcrest.core.Is.isA
 import org.junit.Assert
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -36,6 +34,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
 
     private val testIndexName = javaClass.simpleName.toLowerCase(Locale.ROOT)
 
+    @Suppress("UNCHECKED_CAST")
     fun `test rollover no condition`() {
         val aliasName = "${testIndexName}_alias"
         val indexNameBase = "${testIndexName}_index"
@@ -65,10 +64,15 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
 
         // Need to speed up to second execution where it will trigger the first execution of the action
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Index did not rollover.", mapOf("message" to "Rolled over index"), getExplainManagedIndexMetaData(firstIndex).info) }
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals("Index did not rollover.", "Rolled over index", info["message"])
+            assertNull("Should not have conditions if none specified", info["conditions"])
+        }
         Assert.assertTrue("New rollover index does not exist.", indexExists("$indexNameBase-000002"))
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun `test rollover multi condition byte size`() {
         val aliasName = "${testIndexName}_byte_alias"
         val indexNameBase = "${testIndexName}_index_byte"
@@ -98,36 +102,47 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
 
         // Need to speed up to second execution where it will trigger the first execution of the action
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Index rollover before it met the condition.", mapOf("message" to "Attempting to rollover"), getExplainManagedIndexMetaData(firstIndex).info) }
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals("Index rollover before it met the condition.", "Attempting to rollover", info["message"])
+            val conditions = info["conditions"] as Map<String, Any?>
+            assertEquals("Did not have exclusively min size and min doc count conditions",
+                    setOf(RolloverActionConfig.MIN_SIZE_FIELD, RolloverActionConfig.MIN_DOC_COUNT_FIELD), conditions.keys)
+            val minSize = conditions[RolloverActionConfig.MIN_SIZE_FIELD] as Map<String, Any?>
+            val minDocCount = conditions[RolloverActionConfig.MIN_DOC_COUNT_FIELD] as Map<String, Any?>
+            assertEquals("Did not have min size condition", "10b", minSize["condition"])
+            assertThat("Did not have min size current", minSize["current"], isA(String::class.java))
+            assertEquals("Did not have min doc count condition", 1000000, minDocCount["condition"])
+            assertEquals("Did not have min doc count current", 0, minDocCount["current"])
+        }
 
-        client().makeRequest(
-            RestRequest.Method.PUT.toString(),
-            "$firstIndex/_doc/1111",
-            StringEntity("{ \"testkey\": \"some valueaaaaaaa\" }", ContentType.APPLICATION_JSON)
-        )
-        client().makeRequest(
-            RestRequest.Method.PUT.toString(),
-            "$firstIndex/_doc/2222",
-            StringEntity("{ \"testkey1\": \"some value1\" }", ContentType.APPLICATION_JSON)
-        )
-        client().makeRequest(
-            RestRequest.Method.PUT.toString(),
-            "$firstIndex/_doc/3333",
-            StringEntity("{ \"testkey2\": \"some value2\" }", ContentType.APPLICATION_JSON)
-        )
+        insertSampleData(index = firstIndex, docCount = 5, delay = 0)
 
         // Need to speed up to second execution where it will trigger the first execution of the action
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Index did not rollover.", mapOf("message" to "Rolled over index"), getExplainManagedIndexMetaData(firstIndex).info) }
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals("Index did not rollover", "Rolled over index", info["message"])
+            val conditions = info["conditions"] as Map<String, Any?>
+            assertEquals("Did not have exclusively min size and min doc count conditions",
+                    setOf(RolloverActionConfig.MIN_SIZE_FIELD, RolloverActionConfig.MIN_DOC_COUNT_FIELD), conditions.keys)
+            val minSize = conditions[RolloverActionConfig.MIN_SIZE_FIELD] as Map<String, Any?>
+            val minDocCount = conditions[RolloverActionConfig.MIN_DOC_COUNT_FIELD] as Map<String, Any?>
+            assertEquals("Did not have min size condition", "10b", minSize["condition"])
+            assertThat("Did not have min size current", minSize["current"], isA(String::class.java))
+            assertEquals("Did not have min doc count condition", 1000000, minDocCount["condition"])
+            assertEquals("Did not have min doc count current", 5, minDocCount["current"])
+        }
         Assert.assertTrue("New rollover index does not exist.", indexExists("$indexNameBase-000002"))
     }
 
+    @Suppress("UNCHECKED_CAST")
     fun `test rollover multi condition doc size`() {
         val aliasName = "${testIndexName}_doc_alias"
         val indexNameBase = "${testIndexName}_index_doc"
         val firstIndex = "$indexNameBase-1"
         val policyID = "${testIndexName}_testPolicyName_doc_1"
-        val actionConfig = RolloverActionConfig(ByteSizeValue(10, ByteSizeUnit.TB), 3, null, 0)
+        val actionConfig = RolloverActionConfig(null, 3, TimeValue.timeValueDays(2), 0)
         val states = listOf(State(name = "RolloverAction", actions = listOf(actionConfig), transitions = listOf()))
         val policy = Policy(
             id = policyID,
@@ -151,27 +166,37 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
 
         // Need to speed up to second execution where it will trigger the first execution of the action
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Index rollover before it met the condition.", mapOf("message" to "Attempting to rollover"), getExplainManagedIndexMetaData(firstIndex).info) }
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals("Index rollover before it met the condition.", "Attempting to rollover", info["message"])
+            val conditions = info["conditions"] as Map<String, Any?>
+            assertEquals("Did not have exclusively min age and min doc count conditions",
+                    setOf(RolloverActionConfig.MIN_INDEX_AGE_FIELD, RolloverActionConfig.MIN_DOC_COUNT_FIELD), conditions.keys)
+            val minAge = conditions[RolloverActionConfig.MIN_INDEX_AGE_FIELD] as Map<String, Any?>
+            val minDocCount = conditions[RolloverActionConfig.MIN_DOC_COUNT_FIELD] as Map<String, Any?>
+            assertEquals("Did not have min age condition", "2d", minAge["condition"])
+            assertThat("Did not have min age current", minAge["current"], isA(String::class.java))
+            assertEquals("Did not have min doc count condition", 3, minDocCount["condition"])
+            assertEquals("Did not have min doc count current", 0, minDocCount["current"])
+        }
 
-        client().makeRequest(
-            RestRequest.Method.PUT.toString(),
-            "$firstIndex/_doc/1111",
-            StringEntity("{ \"testkey\": \"some value\" }", ContentType.APPLICATION_JSON)
-        )
-        client().makeRequest(
-            RestRequest.Method.PUT.toString(),
-            "$firstIndex/_doc/2222",
-            StringEntity("{ \"testkey1\": \"some value1\" }", ContentType.APPLICATION_JSON)
-        )
-        client().makeRequest(
-            RestRequest.Method.PUT.toString(),
-            "$firstIndex/_doc/3333",
-            StringEntity("{ \"testkey2\": \"some value2\" }", ContentType.APPLICATION_JSON)
-        )
+        insertSampleData(index = firstIndex, docCount = 5, delay = 0)
 
         // Need to speed up to second execution where it will trigger the first execution of the action
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Index did not rollover.", mapOf("message" to "Rolled over index"), getExplainManagedIndexMetaData(firstIndex).info) }
+        waitFor {
+            val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
+            assertEquals("Index did not rollover", "Rolled over index", info["message"])
+            val conditions = info["conditions"] as Map<String, Any?>
+            assertEquals("Did not have exclusively min age and min doc count conditions",
+                    setOf(RolloverActionConfig.MIN_INDEX_AGE_FIELD, RolloverActionConfig.MIN_DOC_COUNT_FIELD), conditions.keys)
+            val minAge = conditions[RolloverActionConfig.MIN_INDEX_AGE_FIELD] as Map<String, Any?>
+            val minDocCount = conditions[RolloverActionConfig.MIN_DOC_COUNT_FIELD] as Map<String, Any?>
+            assertEquals("Did not have min age condition", "2d", minAge["condition"])
+            assertThat("Did not have min age current", minAge["current"], isA(String::class.java))
+            assertEquals("Did not have min doc count condition", 3, minDocCount["condition"])
+            assertEquals("Did not have min doc count current", 5, minDocCount["current"])
+        }
         Assert.assertTrue("New rollover index does not exist.", indexExists("$indexNameBase-000002"))
     }
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtilsTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/ManagedIndexUtilsTests.kt
@@ -182,49 +182,45 @@ class ManagedIndexUtilsTests : ESTestCase() {
     fun `test rollover action config evaluate conditions`() {
         val noConditionsConfig = RolloverActionConfig(minSize = null, minDocs = null, minAge = null, index = 0)
         assertTrue("No conditions should always pass", noConditionsConfig
-                .evaluateConditions(indexCreationDate = Instant.ofEpochMilli(-1L), numDocs = 0, indexSize = ByteSizeValue(0)))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue(0)))
         assertTrue("No conditions should always pass", noConditionsConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 5, indexSize = ByteSizeValue(5)))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(100), numDocs = 5, indexSize = ByteSizeValue(5)))
         assertTrue("No conditions should always pass", noConditionsConfig
-                .evaluateConditions(indexCreationDate = Instant.now().minusSeconds(600), numDocs = 5, indexSize = ByteSizeValue(5)))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(-6000), numDocs = 5, indexSize = ByteSizeValue(5)))
         assertTrue("No conditions should always pass", noConditionsConfig
-                .evaluateConditions(indexCreationDate = Instant.now().plusSeconds(600), numDocs = 5, indexSize = ByteSizeValue(5)))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(6000), numDocs = 5, indexSize = ByteSizeValue(5)))
 
         val minSizeConfig = RolloverActionConfig(minSize = ByteSizeValue(5), minDocs = null, minAge = null, index = 0)
         assertFalse("Less bytes should not pass", minSizeConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 0, indexSize = ByteSizeValue.ZERO))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO))
         assertTrue("Equal bytes should pass", minSizeConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 0, indexSize = ByteSizeValue(5)))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(5)))
         assertTrue("More bytes should pass", minSizeConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 0, indexSize = ByteSizeValue(10)))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue(10)))
 
         val minDocsConfig = RolloverActionConfig(minSize = null, minDocs = 5, minAge = null, index = 0)
         assertFalse("Less docs should not pass", minDocsConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 0, indexSize = ByteSizeValue.ZERO))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO))
         assertTrue("Equal docs should pass", minDocsConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 5, indexSize = ByteSizeValue.ZERO))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 5, indexSize = ByteSizeValue.ZERO))
         assertTrue("More docs should pass", minDocsConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 10, indexSize = ByteSizeValue.ZERO))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 10, indexSize = ByteSizeValue.ZERO))
 
         val minAgeConfig = RolloverActionConfig(minSize = null, minDocs = null, minAge = TimeValue.timeValueSeconds(5), index = 0)
         assertFalse("Index age that is too young should not pass", minAgeConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 0, indexSize = ByteSizeValue.ZERO))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(1000), numDocs = 0, indexSize = ByteSizeValue.ZERO))
         assertTrue("Index age that is older should pass", minAgeConfig
-                .evaluateConditions(indexCreationDate = Instant.now().minusSeconds(10), numDocs = 0, indexSize = ByteSizeValue.ZERO))
-        assertFalse("Index age that is -1L should not pass", minAgeConfig
-                .evaluateConditions(indexCreationDate = Instant.ofEpochMilli(-1L), numDocs = 0, indexSize = ByteSizeValue.ZERO))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, indexSize = ByteSizeValue.ZERO))
 
         val multiConfig = RolloverActionConfig(minSize = ByteSizeValue(1), minDocs = 1, minAge = TimeValue.timeValueSeconds(5), index = 0)
         assertFalse("No conditions met should not pass", multiConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 0, indexSize = ByteSizeValue.ZERO))
-        assertFalse("Multi condition, index age -1L should not pass", multiConfig
-                .evaluateConditions(indexCreationDate = Instant.ofEpochMilli(-1L), numDocs = 0, indexSize = ByteSizeValue.ZERO))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue.ZERO))
         assertTrue("Multi condition, age should pass", multiConfig
-                .evaluateConditions(indexCreationDate = Instant.now().minusSeconds(10), numDocs = 0, indexSize = ByteSizeValue.ZERO))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(10000), numDocs = 0, indexSize = ByteSizeValue.ZERO))
         assertTrue("Multi condition, docs should pass", multiConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 2, indexSize = ByteSizeValue.ZERO))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 2, indexSize = ByteSizeValue.ZERO))
         assertTrue("Multi condition, size should pass", multiConfig
-                .evaluateConditions(indexCreationDate = Instant.now(), numDocs = 0, indexSize = ByteSizeValue(2)))
+                .evaluateConditions(indexAgeTimeValue = TimeValue.timeValueMillis(0), numDocs = 0, indexSize = ByteSizeValue(2)))
     }
 
     fun `test transition evaluate conditions`() {


### PR DESCRIPTION
*Issue #, if available:*
#171 

*Description of changes:*
This solves half of above issue by showing the rollover conditions in the info object. Transitions will be done at a later time.

We are getting a lot of questions on "why" did the managed index rollover or not rollover. We added some logs but that was only for when it actually does rollover. This now covers both and makes it easy to see exactly why it rolled over (or didn't).

If no conditions are specified then no conditions object will be shown in info (there is an assertion added for this in the tests).

And the conditions will only be shown if they were specified by the user, i.e. if user only chooses to rollover on doc count then only doc count conditions will be shown.

Example images:
![Screen Shot 2020-04-24 at 1 07 35 PM](https://user-images.githubusercontent.com/46505179/80260677-46f7e680-863d-11ea-92de-74b2766c7a1a.png)
![Screen Shot 2020-04-24 at 12 10 07 PM](https://user-images.githubusercontent.com/46505179/80260697-56772f80-863d-11ea-8930-12147e418cd8.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
