### PR TITLE
Fixes snapshot bugs

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/managedindexmetadata/ActionProperties.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/managedindexmetadata/ActionProperties.kt
@@ -27,31 +27,36 @@ import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 
 /** Properties that will persist across steps of a single Action. Will be stored in the [ActionMetaData]. */
 data class ActionProperties(
-    val maxNumSegments: Int? = null
+    val maxNumSegments: Int? = null,
+    val snapshotName: String? = null
 ) : Writeable, ToXContentFragment {
 
     override fun writeTo(out: StreamOutput) {
         out.writeOptionalInt(maxNumSegments)
+        out.writeOptionalString(snapshotName)
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         if (maxNumSegments != null) builder.field(MAX_NUM_SEGMENTS, maxNumSegments)
-
+        if (snapshotName != null) builder.field(SNAPSHOT_NAME, snapshotName)
         return builder
     }
 
     companion object {
         const val ACTION_PROPERTIES = "action_properties"
         const val MAX_NUM_SEGMENTS = "max_num_segments"
+        const val SNAPSHOT_NAME = "snapshot_name"
 
         fun fromStreamInput(si: StreamInput): ActionProperties {
             val maxNumSegments: Int? = si.readOptionalInt()
+            val snapshotName: String? = si.readOptionalString()
 
-            return ActionProperties(maxNumSegments)
+            return ActionProperties(maxNumSegments, snapshotName)
         }
 
         fun parse(xcp: XContentParser): ActionProperties {
             var maxNumSegments: Int? = null
+            var snapshotName: String? = null
 
             ensureExpectedToken(Token.START_OBJECT, xcp.currentToken(), xcp::getTokenLocation)
             while (xcp.nextToken() != Token.END_OBJECT) {
@@ -60,10 +65,11 @@ data class ActionProperties(
 
                 when (fieldName) {
                     MAX_NUM_SEGMENTS -> maxNumSegments = xcp.intValue()
+                    SNAPSHOT_NAME -> snapshotName = xcp.text()
                 }
             }
 
-            return ActionProperties(maxNumSegments)
+            return ActionProperties(maxNumSegments, snapshotName)
         }
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
@@ -48,7 +48,7 @@ class AttemptSnapshotStep(
 
     override fun isIdempotent() = false
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "ComplexMethod")
     override suspend fun execute() {
         try {
             logger.info("Executing snapshot on ${managedIndexMetaData.index}")

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
@@ -68,7 +68,7 @@ class AttemptSnapshotStep(
             when (response.status()) {
                 RestStatus.ACCEPTED -> {
                     stepStatus = StepStatus.COMPLETED
-                    mutableInfo["message"] = "Snapshot creation started and is still in progress for index: ${managedIndexMetaData.index}"
+                    mutableInfo["message"] = "Snapshot creation started for index: ${managedIndexMetaData.index}"
                 }
                 RestStatus.OK -> {
                     stepStatus = StepStatus.COMPLETED

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -463,6 +463,11 @@ abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
         }
     }
 
+    protected fun deleteSnapshot(repository: String, snapshotName: String) {
+        val response = client().makeRequest("DELETE", "_snapshot/$repository/$snapshotName")
+        assertEquals("Unable to delete snapshot", RestStatus.OK, response.restStatus())
+    }
+
     @Suppress("UNCHECKED_CAST")
     protected fun assertSnapshotExists(
         repository: String,


### PR DESCRIPTION
*Issue #, if available:*
#240

*Description of changes:*
There were a few bugs found in snapshot from the #240 issue.
1. The snapshot name was not persisting across multiple WaitForSnapshotStep executions as it was added to the info object and not the ActionProperties.
2. The ConcurrentSnapshotExecutionException that was being caught in AttemptSnapshotStep was not working correctly in multi-node setups as the exception is wrapped in a RemoteTransportException
3. There was no try/catch around the WaitForSnapshotStep execute method


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
