### PR TITLE
Adds codecov yml file to reduce flakiness in coverage check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,12 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: 70%    # the required coverage value
+        threshold: 1%  # the leniency in hitting the target


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds the codecov yml config and sets the minimum target coverage to 70% while allowing a 1% drop.
This should hopefully help with the random X because of test randomization. This only makes the change for the project status check, will see if we need something similar for patch after a few more PRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
