### PR TITLE
Fixes force merge failing on long executions, changes some action mes…

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,6 @@ The project in this package uses the [Gradle](https://docs.gradle.org/current/us
 
 However, to build the `index management` plugin project, we also use the Elastic build tools for Gradle.  These tools are idiosyncratic and don't always follow the conventions and instructions for building regular Java code using Gradle. Not everything in `index management` will work the way it's described in the Gradle documentation. If you encounter such a situation, the Elastic build tools [source code](https://github.com/elastic/elasticsearch/tree/master/buildSrc/src/main/groovy/org/elasticsearch/gradle) is your best bet for figuring out what's going on.
 
-This project currently uses the Notification subproject from the [Alerting plugin](https://github.com/opendistro-for-elasticsearch/alerting). There is an [open PR](https://github.com/opendistro-for-elasticsearch/alerting/pull/97) that introduces the maven publish task in Alerting for publishing the Notification jars. Until this PR is fully merged and jars published you will need to pull down the PR yourself and publish the jars to your local maven repository in order to build Index Management.
-
-1. Visit the PR [here](https://github.com/opendistro-for-elasticsearch/alerting/pull/97) and pull down the Alerting plugin along with the PR changes
-2. You may need to cherry-pick the changes into a separate branch if you require a specific version to be published
-3. Build the Alerting plugin (w/ the changes in PR) and publish the artifacts to your local maven repository
-     1. `./gradlew clean`
-     2. `./gradlew build` or `./gradlew assemble` build will run the tests and build artifacts, assemble will only build the artifacts
-     3. `./gradlew publishToMavenLocal` publishes artifacts to your local maven repository
-
 ### Building from the command line
 
 1. `./gradlew build` builds and tests project.

--- a/build-tools/esplugin-coverage.gradle
+++ b/build-tools/esplugin-coverage.gradle
@@ -58,7 +58,7 @@ integTest.runner {
 jacocoTestReport {
     dependsOn integTest, test
     executionData dummyTest.jacoco.destinationFile, dummyIntegTest.jacoco.destinationFile
-    sourceDirectories.from = sourceSets.main.allSource
+    sourceDirectories.from = "src/main/kotlin"
     classDirectories.from = sourceSets.main.output
     reports {
         html.enabled = true // human readable

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/ManagedIndexRunner.kt
@@ -290,7 +290,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
 
         if (updateResult && state != null && action != null && step != null && currentActionMetaData != null) {
             // Step null check is done in getStartingManagedIndexMetaData
-            step.execute()
+            step.preExecute(logger).execute().postExecute(logger)
             var executedManagedIndexMetaData = startingManagedIndexMetaData.getCompletedManagedIndexMetaData(action, step)
 
             if (executedManagedIndexMetaData.isFailed) {

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/elasticapi/ElasticExtensions.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/elasticapi/ElasticExtensions.kt
@@ -24,8 +24,10 @@ import com.amazon.opendistroforelasticsearch.jobscheduler.spi.utils.LockService
 import kotlinx.coroutines.delay
 import org.apache.logging.log4j.Logger
 import org.elasticsearch.ElasticsearchException
+import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.ActionListener
 import org.elasticsearch.action.bulk.BackoffPolicy
+import org.elasticsearch.action.support.DefaultShardOperationFailedException
 import org.elasticsearch.client.ElasticsearchClient
 import org.elasticsearch.cluster.metadata.IndexMetadata
 import org.elasticsearch.common.bytes.BytesReference
@@ -36,6 +38,7 @@ import org.elasticsearch.common.xcontent.XContentParser
 import org.elasticsearch.common.xcontent.XContentParserUtils
 import org.elasticsearch.common.xcontent.XContentType
 import org.elasticsearch.rest.RestStatus
+import org.elasticsearch.transport.RemoteTransportException
 import java.time.Instant
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -202,9 +205,7 @@ fun IndexMetadata.getRolloverAlias(): String? {
 fun IndexMetadata.getClusterStateManagedIndexConfig(): ClusterStateManagedIndexConfig? {
     val index = this.index.name
     val uuid = this.index.uuid
-    val policyID = this.getPolicyID()
-
-    if (policyID == null) return null
+    val policyID = this.getPolicyID() ?: return null
 
     return ClusterStateManagedIndexConfig(index = index, uuid = uuid, policyID = policyID)
 }
@@ -216,4 +217,14 @@ fun IndexMetadata.getManagedIndexMetaData(): ManagedIndexMetaData? {
         return ManagedIndexMetaData.fromMap(existingMetaDataMap)
     }
     return null
+}
+
+fun Throwable.findRemoteTransportException(): RemoteTransportException? {
+    if (this is RemoteTransportException) return this
+    return this.cause?.findRemoteTransportException()
+}
+
+fun DefaultShardOperationFailedException.getUsefulCauseString(): String {
+    val rte = this.cause?.findRemoteTransportException()
+    return if (rte == null) this.toString() else ExceptionsHelper.unwrapCause(rte).toString()
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/coordinator/SweptManagedIndexConfig.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/coordinator/SweptManagedIndexConfig.kt
@@ -40,6 +40,7 @@ data class SweptManagedIndexConfig(
 ) {
 
     companion object {
+        @Suppress("ComplexMethod")
         @JvmStatic
         @Throws(IOException::class)
         fun parse(xcp: XContentParser, seqNo: Long, primaryTerm: Long): SweptManagedIndexConfig {

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/Step.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/Step.kt
@@ -30,6 +30,7 @@ abstract class Step(val name: String, val managedIndexMetaData: ManagedIndexMeta
         logger.info("Executing $name for ${managedIndexMetaData.index}")
         return this
     }
+
     abstract suspend fun execute(): Step
 
     fun postExecute(logger: Logger): Step {

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/Step.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/Step.kt
@@ -17,6 +17,7 @@ package com.amazon.opendistroforelasticsearch.indexstatemanagement.step
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StepMetaData
+import org.apache.logging.log4j.Logger
 import org.elasticsearch.common.io.stream.StreamInput
 import org.elasticsearch.common.io.stream.StreamOutput
 import org.elasticsearch.common.io.stream.Writeable
@@ -25,7 +26,16 @@ import java.util.Locale
 
 abstract class Step(val name: String, val managedIndexMetaData: ManagedIndexMetaData, val isSafeToDisableOn: Boolean = true) {
 
-    abstract suspend fun execute()
+    fun preExecute(logger: Logger): Step {
+        logger.info("Executing $name for ${managedIndexMetaData.index}")
+        return this
+    }
+    abstract suspend fun execute(): Step
+
+    fun postExecute(logger: Logger): Step {
+        logger.info("Finished executing $name for ${managedIndexMetaData.index}")
+        return this
+    }
 
     abstract fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData
 
@@ -44,9 +54,7 @@ abstract class Step(val name: String, val managedIndexMetaData: ManagedIndexMeta
      */
     abstract fun isIdempotent(): Boolean
 
-    fun getStartingStepMetaData(): StepMetaData {
-        return StepMetaData(name, getStepStartTime().toEpochMilli(), StepStatus.STARTING)
-    }
+    fun getStartingStepMetaData(): StepMetaData = StepMetaData(name, getStepStartTime().toEpochMilli(), StepStatus.STARTING)
 
     fun getStepStartTime(): Instant {
         if (managedIndexMetaData.stepMetaData == null || managedIndexMetaData.stepMetaData.name != this.name) {
@@ -54,6 +62,8 @@ abstract class Step(val name: String, val managedIndexMetaData: ManagedIndexMeta
         }
         return Instant.ofEpochMilli(managedIndexMetaData.stepMetaData.startTime)
     }
+
+    protected val indexName: String = managedIndexMetaData.index
 
     enum class StepStatus(val status: String) : Writeable {
         STARTING("starting"),

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/allocation/AttemptAllocationStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/allocation/AttemptAllocationStep.kt
@@ -39,20 +39,17 @@ class AttemptAllocationStep(
 
     override fun isIdempotent() = true
 
-    override suspend fun execute() {
+    override suspend fun execute(): AttemptAllocationStep {
         try {
             val response: AcknowledgedResponse = client.admin()
                 .indices()
                 .suspendUntil { updateSettings(UpdateSettingsRequest(buildSettings(), managedIndexMetaData.index), it) }
             handleResponse(response)
         } catch (e: Exception) {
-            logger.error(ERROR_MESSAGE, e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to ERROR_MESSAGE)
-            val errorMessage = e.message
-            if (errorMessage != null) mutableInfo["cause"] = errorMessage
-            info = mutableInfo.toMap()
+            resolveException(e)
         }
+
+        return this
     }
 
     private fun buildSettings(): Settings {
@@ -63,13 +60,23 @@ class AttemptAllocationStep(
         return builder.build()
     }
 
+    private fun resolveException(e: Exception) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
+    }
+
     private fun handleResponse(response: AcknowledgedResponse) {
         if (response.isAcknowledged) {
             stepStatus = StepStatus.COMPLETED
-            info = mapOf("message" to "Updated settings with allocation.")
+            info = mapOf("message" to getSuccessMessage(indexName))
         } else {
             stepStatus = StepStatus.FAILED
-            info = mapOf("message" to ERROR_MESSAGE)
+            info = mapOf("message" to getFailedMessage(indexName))
         }
     }
 
@@ -82,7 +89,8 @@ class AttemptAllocationStep(
     }
 
     companion object {
-        private const val ERROR_MESSAGE = "Failed to update settings with allocation."
         private const val SETTINGS_PREFIX = "index.routing.allocation."
+        fun getFailedMessage(index: String) = "Failed to update allocation setting [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully updated allocation setting [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/allocation/AttemptAllocationStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/allocation/AttemptAllocationStep.kt
@@ -46,7 +46,7 @@ class AttemptAllocationStep(
                 .suspendUntil { updateSettings(UpdateSettingsRequest(buildSettings(), managedIndexMetaData.index), it) }
             handleResponse(response)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
@@ -60,7 +60,7 @@ class AttemptAllocationStep(
         return builder.build()
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/close/AttemptCloseStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/close/AttemptCloseStep.kt
@@ -61,27 +61,27 @@ class AttemptCloseStep(
         } catch (e: RemoteTransportException) {
             val cause = ExceptionsHelper.unwrapCause(e)
             if (cause is SnapshotInProgressException) {
-                resolveSnapshotException(cause)
+                handleSnapshotException(cause)
             } else {
-                resolveException(cause as Exception)
+                handleException(cause as Exception)
             }
         } catch (e: SnapshotInProgressException) {
-            resolveSnapshotException(e)
+            handleSnapshotException(e)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveSnapshotException(e: SnapshotInProgressException) {
+    private fun handleSnapshotException(e: SnapshotInProgressException) {
         val message = getSnapshotMessage(indexName)
         logger.warn(message, e)
         stepStatus = StepStatus.CONDITION_NOT_MET
         info = mapOf("message" to message)
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/delete/AttemptDeleteStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/delete/AttemptDeleteStep.kt
@@ -61,27 +61,27 @@ class AttemptDeleteStep(
         } catch (e: RemoteTransportException) {
             val cause = ExceptionsHelper.unwrapCause(e)
             if (cause is SnapshotInProgressException) {
-                resolveSnapshotException(cause)
+                handleSnapshotException(cause)
             } else {
-                resolveException(cause as Exception)
+                handleException(cause as Exception)
             }
         } catch (e: SnapshotInProgressException) {
-            resolveSnapshotException(e)
+            handleSnapshotException(e)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveSnapshotException(e: SnapshotInProgressException) {
+    private fun handleSnapshotException(e: SnapshotInProgressException) {
         val message = getSnapshotMessage(indexName)
         logger.warn(message, e)
         stepStatus = StepStatus.CONDITION_NOT_MET
         info = mapOf("message" to message)
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/AttemptCallForceMergeStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/AttemptCallForceMergeStep.kt
@@ -15,18 +15,27 @@
 
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.step.forcemerge
 
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.getUsefulCauseString
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.suspendUntil
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ForceMergeActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.ActionProperties
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.elasticsearch.client.Client
 import org.elasticsearch.cluster.service.ClusterService
 import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeRequest
 import org.elasticsearch.action.admin.indices.forcemerge.ForceMergeResponse
 import org.elasticsearch.rest.RestStatus
+import org.elasticsearch.transport.RemoteTransportException
+import java.time.Instant
 
 class AttemptCallForceMergeStep(
     val clusterService: ClusterService,
@@ -42,35 +51,61 @@ class AttemptCallForceMergeStep(
     override fun isIdempotent() = false
 
     @Suppress("TooGenericExceptionCaught")
-    override suspend fun execute() {
+    override suspend fun execute(): AttemptCallForceMergeStep {
         try {
-            val indexName = managedIndexMetaData.index
 
-            logger.info("Attempting to force merge on [$indexName]")
+            val startTime = Instant.now().toEpochMilli()
             val request = ForceMergeRequest(indexName).maxNumSegments(config.maxNumSegments)
-            val response: ForceMergeResponse = client.admin().indices().suspendUntil { forceMerge(request, it) }
+            var response: ForceMergeResponse? = null
+            var throwable: Throwable? = null
+            GlobalScope.launch(Dispatchers.IO + CoroutineName("ISM-ForceMerge-$indexName")) {
+                try {
+                    response = client.admin().indices().suspendUntil { forceMerge(request, it) }
+                    if (response?.status == RestStatus.OK) {
+                        logger.info(getSuccessMessage(indexName))
+                    } else {
+                        logger.warn(getFailedMessage(indexName))
+                    }
+                } catch (t: Throwable) {
+                    throwable = t
+                }
+            }
 
-            // If response is OK then the force merge operation has started
-            if (response.status == RestStatus.OK) {
+            while (response == null && (Instant.now().toEpochMilli() - startTime) < FIVE_MINUTES_IN_MILLIS) {
+                delay(FIVE_SECONDS_IN_MILLIS)
+                throwable?.let { throw it }
+            }
+
+            val shadowedResponse = response
+            if (shadowedResponse?.let { it.status == RestStatus.OK } != false) {
                 stepStatus = StepStatus.COMPLETED
-                info = mapOf("message" to "Started force merge")
+                info = mapOf("message" to getSuccessMessage(indexName))
             } else {
                 // Otherwise the request to force merge encountered some problem
                 stepStatus = StepStatus.FAILED
                 info = mapOf(
-                    "message" to "Failed to start force merge",
-                    "status" to response.status,
-                    "shard_failures" to response.shardFailures.map { it.toString() }
+                    "message" to getFailedMessage(indexName),
+                    "status" to shadowedResponse.status,
+                    "shard_failures" to shadowedResponse.shardFailures.map { it.getUsefulCauseString() }
                 )
             }
+        } catch (e: RemoteTransportException) {
+            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            logger.error("Failed to start force merge [index=${managedIndexMetaData.index}]", e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to "Failed to start force merge")
-            val errorMessage = e.message
-            if (errorMessage != null) mutableInfo["cause"] = errorMessage
-            info = mutableInfo.toMap()
+            resolveException(e)
         }
+
+        return this
+    }
+
+    private fun resolveException(e: Exception) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData {
@@ -87,5 +122,9 @@ class AttemptCallForceMergeStep(
 
     companion object {
         const val name = "attempt_call_force_merge"
+        const val FIVE_MINUTES_IN_MILLIS = 1000 * 60 * 5 // how long to wait for the force merge request before moving on
+        const val FIVE_SECONDS_IN_MILLIS = 1000L * 5L // delay
+        fun getFailedMessage(index: String) = "Failed to start force merge [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully completed force merge [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/AttemptCallForceMergeStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/AttemptCallForceMergeStep.kt
@@ -79,7 +79,7 @@ class AttemptCallForceMergeStep(
             val shadowedResponse = response
             if (shadowedResponse?.let { it.status == RestStatus.OK } != false) {
                 stepStatus = StepStatus.COMPLETED
-                info = mapOf("message" to getSuccessMessage(indexName))
+                info = mapOf("message" to if (shadowedResponse == null) getSuccessfulCallMessage(indexName) else getSuccessMessage(indexName))
             } else {
                 // Otherwise the request to force merge encountered some problem
                 stepStatus = StepStatus.FAILED
@@ -90,15 +90,15 @@ class AttemptCallForceMergeStep(
                 )
             }
         } catch (e: RemoteTransportException) {
-            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
+            handleException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED
@@ -125,6 +125,7 @@ class AttemptCallForceMergeStep(
         const val FIVE_MINUTES_IN_MILLIS = 1000 * 60 * 5 // how long to wait for the force merge request before moving on
         const val FIVE_SECONDS_IN_MILLIS = 1000L * 5L // delay
         fun getFailedMessage(index: String) = "Failed to start force merge [index=$index]"
+        fun getSuccessfulCallMessage(index: String) = "Successfully called force merge [index=$index]"
         fun getSuccessMessage(index: String) = "Successfully completed force merge [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/AttemptSetReadOnlyStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/AttemptSetReadOnlyStep.kt
@@ -77,15 +77,15 @@ class AttemptSetReadOnlyStep(
             stepStatus = StepStatus.FAILED
             info = mapOf("message" to message)
         } catch (e: RemoteTransportException) {
-            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
+            handleException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return false
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/AttemptSetReadOnlyStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/forcemerge/AttemptSetReadOnlyStep.kt
@@ -21,12 +21,14 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.F
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
 import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.action.support.master.AcknowledgedResponse
 import org.elasticsearch.client.Client
-import org.elasticsearch.cluster.metadata.IndexMetadata
+import org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.transport.RemoteTransportException
 
 class AttemptSetReadOnlyStep(
     val clusterService: ClusterService,
@@ -41,18 +43,17 @@ class AttemptSetReadOnlyStep(
 
     override fun isIdempotent() = true
 
-    override suspend fun execute() {
-        val indexName = managedIndexMetaData.index
-
-        logger.info("Attempting to set [$indexName] to read-only for force_merge action")
+    override suspend fun execute(): AttemptSetReadOnlyStep {
         val indexSetToReadOnly = setIndexToReadOnly(indexName)
 
         // If setIndexToReadOnly returns false, updating settings failed and failed info was already updated, can return early
-        if (!indexSetToReadOnly) return
+        if (!indexSetToReadOnly) return this
 
         // Complete step since index is read-only
         stepStatus = StepStatus.COMPLETED
-        info = mapOf("message" to "Set index to read-only")
+        info = mapOf("message" to getSuccessMessage(indexName))
+
+        return this
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -61,30 +62,37 @@ class AttemptSetReadOnlyStep(
             val updateSettingsRequest = UpdateSettingsRequest()
                 .indices(indexName)
                 .settings(
-                    Settings.builder().put(IndexMetadata.SETTING_BLOCKS_WRITE, true)
+                    Settings.builder().put(SETTING_BLOCKS_WRITE, true)
                 )
             val response: AcknowledgedResponse = client.admin().indices()
                 .suspendUntil { updateSettings(updateSettingsRequest, it) }
 
             if (response.isAcknowledged) {
-                logger.info("Successfully set [$indexName] to read-only for force_merge action")
                 return true
             }
 
             // If response is not acknowledged, then add failed info
-            logger.error("Request to set [$indexName] to read-only was NOT acknowledged")
+            val message = getFailedMessage(indexName)
+            logger.warn(message)
             stepStatus = StepStatus.FAILED
-            info = mapOf("message" to "Failed to set index to read-only")
+            info = mapOf("message" to message)
+        } catch (e: RemoteTransportException) {
+            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            logger.error("Failed to set index to read-only [index=${managedIndexMetaData.index}]", e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to "Failed to set index to read-only")
-            val errorMessage = e.message
-            if (errorMessage != null) mutableInfo["cause"] = errorMessage
-            info = mutableInfo.toMap()
+            resolveException(e)
         }
 
         return false
+    }
+
+    private fun resolveException(e: Exception) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData =
@@ -92,5 +100,7 @@ class AttemptSetReadOnlyStep(
 
     companion object {
         const val name = "attempt_set_read_only"
+        fun getFailedMessage(index: String) = "Failed to set index to read-only [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully set index to read-only [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/indexpriority/AttemptSetIndexPriorityStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/indexpriority/AttemptSetIndexPriorityStep.kt
@@ -21,11 +21,14 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.I
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
 import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.action.support.master.AcknowledgedResponse
 import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_PRIORITY
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.transport.RemoteTransportException
 
 class AttemptSetIndexPriorityStep(
     val clusterService: ClusterService,
@@ -41,32 +44,40 @@ class AttemptSetIndexPriorityStep(
     override fun isIdempotent() = true
 
     @Suppress("TooGenericExceptionCaught")
-    override suspend fun execute() {
-        val indexPriority = config.indexPriority
+    override suspend fun execute(): AttemptSetIndexPriorityStep {
         try {
-            logger.info("Executing $name on ${managedIndexMetaData.index}")
             val updateSettingsRequest = UpdateSettingsRequest()
                     .indices(managedIndexMetaData.index)
-                    .settings(Settings.builder().put("index.priority", indexPriority))
+                    .settings(Settings.builder().put(SETTING_PRIORITY, config.indexPriority))
             val response: AcknowledgedResponse = client.admin().indices()
                     .suspendUntil { updateSettings(updateSettingsRequest, it) }
 
             if (response.isAcknowledged) {
-                logger.info("Successfully executed $name on ${managedIndexMetaData.index}")
                 stepStatus = StepStatus.COMPLETED
-                info = mapOf("message" to "Successfully set index priority to $indexPriority")
+                info = mapOf("message" to getSuccessMessage(indexName, config.indexPriority))
             } else {
+                val message = getFailedMessage(indexName, config.indexPriority)
+                logger.warn(message)
                 stepStatus = StepStatus.FAILED
-                info = mapOf("message" to "Failed to set index priority to $indexPriority")
+                info = mapOf("message" to message)
             }
+        } catch (e: RemoteTransportException) {
+            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            logger.error("Failed to set index priority [index=${managedIndexMetaData.index}]", e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to "Failed to set index priority to $indexPriority")
-            val errorMessage = e.message
-            if (errorMessage != null) mutableInfo["cause"] = errorMessage
-            info = mutableInfo.toMap()
+            resolveException(e)
         }
+
+        return this
+    }
+
+    private fun resolveException(e: Exception) {
+        val message = getFailedMessage(indexName, config.indexPriority)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData {
@@ -75,5 +86,10 @@ class AttemptSetIndexPriorityStep(
             transitionTo = null,
             info = info
         )
+    }
+
+    companion object {
+        fun getFailedMessage(index: String, indexPriority: Int) = "Failed to set index priority to $indexPriority [index=$index]"
+        fun getSuccessMessage(index: String, indexPriority: Int) = "Successfully set index priority to $indexPriority [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/indexpriority/AttemptSetIndexPriorityStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/indexpriority/AttemptSetIndexPriorityStep.kt
@@ -62,15 +62,15 @@ class AttemptSetIndexPriorityStep(
                 info = mapOf("message" to message)
             }
         } catch (e: RemoteTransportException) {
-            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
+            handleException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName, config.indexPriority)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/notification/AttemptNotificationStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/notification/AttemptNotificationStep.kt
@@ -54,13 +54,13 @@ class AttemptNotificationStep(
             stepStatus = StepStatus.COMPLETED
             info = mapOf("message" to getSuccessMessage(indexName))
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/open/AttemptOpenStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/open/AttemptOpenStep.kt
@@ -58,15 +58,15 @@ class AttemptOpenStep(
                 info = mapOf("message" to message)
             }
         } catch (e: RemoteTransportException) {
-            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
+            handleException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/readonly/SetReadOnlyStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/readonly/SetReadOnlyStep.kt
@@ -62,15 +62,15 @@ class SetReadOnlyStep(
                 info = mapOf("message" to message)
             }
         } catch (e: RemoteTransportException) {
-            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
+            handleException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/readonly/SetReadOnlyStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/readonly/SetReadOnlyStep.kt
@@ -21,11 +21,14 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.R
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
 import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.action.support.master.AcknowledgedResponse
 import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.transport.RemoteTransportException
 
 class SetReadOnlyStep(
     val clusterService: ClusterService,
@@ -41,31 +44,42 @@ class SetReadOnlyStep(
     override fun isIdempotent() = true
 
     @Suppress("TooGenericExceptionCaught")
-    override suspend fun execute() {
+    override suspend fun execute(): SetReadOnlyStep {
         try {
             val updateSettingsRequest = UpdateSettingsRequest()
-                .indices(managedIndexMetaData.index)
+                .indices(indexName)
                 .settings(
-                    Settings.builder().put("index.blocks.write", true)
+                    Settings.builder().put(SETTING_BLOCKS_WRITE, true)
                 )
             val response: AcknowledgedResponse = client.admin().indices()
                 .suspendUntil { updateSettings(updateSettingsRequest, it) }
 
             if (response.isAcknowledged) {
                 stepStatus = StepStatus.COMPLETED
-                info = mapOf("message" to "Set index to read-only")
+                info = mapOf("message" to getSuccessMessage(indexName))
             } else {
+                val message = getFailedMessage(indexName)
+                logger.warn(message)
                 stepStatus = StepStatus.FAILED
-                info = mapOf("message" to "Failed to set index to read-only")
+                info = mapOf("message" to message)
             }
+        } catch (e: RemoteTransportException) {
+            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            logger.error("Failed to set index to read-only [index=${managedIndexMetaData.index}]", e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to "Failed to set index to read-only")
-            val errorMessage = e.message
-            if (errorMessage != null) mutableInfo["cause"] = errorMessage
-            info = mutableInfo.toMap()
+            resolveException(e)
         }
+
+        return this
+    }
+
+    private fun resolveException(e: Exception) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData {
@@ -74,5 +88,10 @@ class SetReadOnlyStep(
             transitionTo = null,
             info = info
         )
+    }
+
+    companion object {
+        fun getFailedMessage(index: String) = "Failed to set index to read-only [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully set index to read-only [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/readonly/SetReadOnlyStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/readonly/SetReadOnlyStep.kt
@@ -48,9 +48,7 @@ class SetReadOnlyStep(
         try {
             val updateSettingsRequest = UpdateSettingsRequest()
                 .indices(indexName)
-                .settings(
-                    Settings.builder().put(SETTING_BLOCKS_WRITE, true)
-                )
+                .settings(Settings.builder().put(SETTING_BLOCKS_WRITE, true))
             val response: AcknowledgedResponse = client.admin().indices()
                 .suspendUntil { updateSettings(updateSettingsRequest, it) }
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/readwrite/SetReadWriteStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/readwrite/SetReadWriteStep.kt
@@ -21,11 +21,14 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.R
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
 import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.action.support.master.AcknowledgedResponse
 import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_BLOCKS_WRITE
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.transport.RemoteTransportException
 
 class SetReadWriteStep(
     val clusterService: ClusterService,
@@ -41,31 +44,42 @@ class SetReadWriteStep(
     override fun isIdempotent() = true
 
     @Suppress("TooGenericExceptionCaught")
-    override suspend fun execute() {
+    override suspend fun execute(): SetReadWriteStep {
         try {
             val updateSettingsRequest = UpdateSettingsRequest()
-                .indices(managedIndexMetaData.index)
+                .indices(indexName)
                 .settings(
-                    Settings.builder().put("index.blocks.write", false)
+                    Settings.builder().put(SETTING_BLOCKS_WRITE, false)
                 )
             val response: AcknowledgedResponse = client.admin().indices()
                 .suspendUntil { updateSettings(updateSettingsRequest, it) }
 
             if (response.isAcknowledged) {
                 stepStatus = StepStatus.COMPLETED
-                info = mapOf("message" to "Set index to read-write")
+                info = mapOf("message" to getSuccessMessage(indexName))
             } else {
+                val message = getFailedMessage(indexName)
+                logger.warn(message)
                 stepStatus = StepStatus.FAILED
-                info = mapOf("message" to "Failed to set index to read-write")
+                info = mapOf("message" to message)
             }
+        } catch (e: RemoteTransportException) {
+            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            logger.error("Failed to set index to read-write [index=${managedIndexMetaData.index}]", e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to "Failed to set index to read-write")
-            val errorMessage = e.message
-            if (errorMessage != null) mutableInfo["cause"] = errorMessage
-            info = mutableInfo.toMap()
+            resolveException(e)
         }
+
+        return this
+    }
+
+    private fun resolveException(e: Exception) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData {
@@ -74,5 +88,10 @@ class SetReadWriteStep(
             transitionTo = null,
             info = info
         )
+    }
+
+    companion object {
+        fun getFailedMessage(index: String) = "Failed to set index to read-write [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully set index to read-write [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/readwrite/SetReadWriteStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/readwrite/SetReadWriteStep.kt
@@ -64,15 +64,15 @@ class SetReadWriteStep(
                 info = mapOf("message" to message)
             }
         } catch (e: RemoteTransportException) {
-            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
+            handleException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/replicacount/AttemptSetReplicaCountStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/replicacount/AttemptSetReplicaCountStep.kt
@@ -63,15 +63,15 @@ class AttemptSetReplicaCountStep(
                 info = mapOf("message" to message)
             }
         } catch (e: RemoteTransportException) {
-            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
+            handleException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName, numOfReplicas)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/replicacount/AttemptSetReplicaCountStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/replicacount/AttemptSetReplicaCountStep.kt
@@ -21,11 +21,14 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.R
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
 import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
 import org.elasticsearch.action.support.master.AcknowledgedResponse
 import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.transport.RemoteTransportException
 
 class AttemptSetReplicaCountStep(
     val clusterService: ClusterService,
@@ -37,36 +40,45 @@ class AttemptSetReplicaCountStep(
     private val logger = LogManager.getLogger(javaClass)
     private var stepStatus = StepStatus.STARTING
     private var info: Map<String, Any>? = null
+    private val numOfReplicas = config.numOfReplicas
 
     override fun isIdempotent() = true
 
     @Suppress("TooGenericExceptionCaught")
-    override suspend fun execute() {
-        val numOfReplicas = config.numOfReplicas
+    override suspend fun execute(): AttemptSetReplicaCountStep {
         try {
-            logger.info("Executing $name on ${managedIndexMetaData.index}")
             val updateSettingsRequest = UpdateSettingsRequest()
-                    .indices(managedIndexMetaData.index)
-                    .settings(Settings.builder().put("index.number_of_replicas", numOfReplicas))
+                    .indices(indexName)
+                    .settings(Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, numOfReplicas))
             val response: AcknowledgedResponse = client.admin().indices()
                     .suspendUntil { updateSettings(updateSettingsRequest, it) }
 
             if (response.isAcknowledged) {
-                logger.info("Successfully executed $name on ${managedIndexMetaData.index}")
                 stepStatus = StepStatus.COMPLETED
-                info = mapOf("message" to "Set number_of_replicas to $numOfReplicas")
+                info = mapOf("message" to getSuccessMessage(indexName, numOfReplicas))
             } else {
+                val message = getFailedMessage(indexName, numOfReplicas)
+                logger.warn(message)
                 stepStatus = StepStatus.FAILED
-                info = mapOf("message" to "Failed to set number_of_replicas to $numOfReplicas")
+                info = mapOf("message" to message)
             }
+        } catch (e: RemoteTransportException) {
+            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            logger.error("Failed to set number_of_replicas [index=${managedIndexMetaData.index}]", e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to "Failed to set number_of_replicas to $numOfReplicas")
-            val errorMessage = e.message
-            if (errorMessage != null) mutableInfo["cause"] = errorMessage
-            info = mutableInfo.toMap()
+            resolveException(e)
         }
+
+        return this
+    }
+
+    private fun resolveException(e: Exception) {
+        val message = getFailedMessage(indexName, numOfReplicas)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData {
@@ -75,5 +87,10 @@ class AttemptSetReplicaCountStep(
             transitionTo = null,
             info = info
         )
+    }
+
+    companion object {
+        fun getFailedMessage(index: String, numOfReplicas: Int) = "Failed to set number_of_replicas to $numOfReplicas [index=$index]"
+        fun getSuccessMessage(index: String, numOfReplicas: Int) = "Successfully set number_of_replicas to $numOfReplicas [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -55,7 +55,7 @@ class AttemptRolloverStep(
         if (managedIndexMetaData.rolledOver == true) {
             logger.warn("$indexName was already rolled over, cannot execute rollover step")
             stepStatus = StepStatus.FAILED
-            info = mapOf("message" to getFailedDuplicateRollover(indexName))
+            info = mapOf("message" to getFailedDuplicateRolloverMessage(indexName))
             return this
         }
 
@@ -139,7 +139,7 @@ class AttemptRolloverStep(
                 ).toMap()
             }
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
     }
 
@@ -186,7 +186,7 @@ class AttemptRolloverStep(
         return null
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED
@@ -210,7 +210,7 @@ class AttemptRolloverStep(
         fun getFailedAliasUpdateMessage(index: String, newIndex: String) =
             "New index created, but failed to update alias [index=$index, newIndex=$newIndex]"
         fun getFailedNoValidAliasMessage(index: String) = "Missing rollover_alias index setting [index=$index]"
-        fun getFailedDuplicateRollover(index: String) = "Index has already been rolled over [index=$index]"
+        fun getFailedDuplicateRolloverMessage(index: String) = "Index has already been rolled over [index=$index]"
         fun getFailedEvaluateMessage(index: String) = "Failed to evaluate conditions for rollover [index=$index]"
         fun getAttemptingMessage(index: String) = "Attempting to rollover index [index=$index]"
         fun getSuccessMessage(index: String) = "Successfully rolled over index [index=$index]"

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/rollover/AttemptRolloverStep.kt
@@ -16,6 +16,7 @@
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.step.rollover
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.getRolloverAlias
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.getUsefulCauseString
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.suspendUntil
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.RolloverActionConfig
@@ -49,27 +50,26 @@ class AttemptRolloverStep(
     override fun isIdempotent() = false
 
     @Suppress("TooGenericExceptionCaught")
-    override suspend fun execute() {
-        val index = managedIndexMetaData.index
+    override suspend fun execute(): AttemptRolloverStep {
         // If we have already rolled over this index then fail as we only allow an index to be rolled over once
         if (managedIndexMetaData.rolledOver == true) {
-            logger.warn("$index was already rolled over, cannot execute rollover step")
+            logger.warn("$indexName was already rolled over, cannot execute rollover step")
             stepStatus = StepStatus.FAILED
-            info = mapOf("message" to "This index has already been rolled over")
-            return
+            info = mapOf("message" to getFailedDuplicateRollover(indexName))
+            return this
         }
 
         val alias = getAliasOrUpdateInfo()
         // If alias is null we already updated failed info from getAliasOrUpdateInfo and can return early
-        alias ?: return
+        alias ?: return this
 
         val statsResponse = getIndexStatsOrUpdateInfo()
         // If statsResponse is null we already updated failed info from getIndexStatsOrUpdateInfo and can return early
-        statsResponse ?: return
+        statsResponse ?: return this
 
-        val indexCreationDate = clusterService.state().metadata().index(index).creationDate
+        val indexCreationDate = clusterService.state().metadata().index(indexName).creationDate
         val indexAgeTimeValue = if (indexCreationDate == -1L) {
-            logger.warn("$index had an indexCreationDate=-1L, cannot use for comparison")
+            logger.warn("$indexName had an indexCreationDate=-1L, cannot use for comparison")
             // since we cannot use for comparison, we can set it to 0 as minAge will never be <= 0
             TimeValue.timeValueMillis(0)
         } else {
@@ -100,13 +100,15 @@ class AttemptRolloverStep(
         ).toMap()
 
         if (config.evaluateConditions(indexAgeTimeValue, numDocs, indexSize)) {
-            logger.info("$index rollover conditions evaluated to true [indexCreationDate=$indexCreationDate," +
+            logger.info("$indexName rollover conditions evaluated to true [indexCreationDate=$indexCreationDate," +
                     " numDocs=$numDocs, indexSize=${indexSize.bytes}]")
             executeRollover(alias, conditions)
         } else {
             stepStatus = StepStatus.CONDITION_NOT_MET
-            info = mapOf("message" to "Attempting to rollover", "conditions" to conditions)
+            info = mapOf("message" to getAttemptingMessage(indexName), "conditions" to conditions)
         }
+
+        return this
     }
 
     @Suppress("ComplexMethod")
@@ -122,34 +124,33 @@ class AttemptRolloverStep(
             if (response.isAcknowledged) {
                 stepStatus = StepStatus.COMPLETED
                 info = listOfNotNull(
-                    "message" to "Rolled over index",
+                    "message" to getSuccessMessage(indexName),
                     if (conditions.isEmpty()) null else "conditions" to conditions // don't show empty conditions object if no conditions specified
                 ).toMap()
             } else {
                 // If the alias update response is NOT acknowledged we will get back isAcknowledged=false
                 // This means the new index was created but we failed to swap the alias
+                val message = getFailedAliasUpdateMessage(indexName, response.newIndex)
+                logger.warn(message)
                 stepStatus = StepStatus.FAILED
                 info = listOfNotNull(
-                    "message" to "New index created (${response.newIndex}), but failed to update alias",
+                    "message" to message,
                     if (conditions.isEmpty()) null else "conditions" to conditions // don't show empty conditions object if no conditions specified
                 ).toMap()
             }
         } catch (e: Exception) {
-            logger.error("Failed to rollover index [index=${managedIndexMetaData.index}]", e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to "Failed to rollover index")
-            val errorMessage = e.message
-            if (errorMessage != null) mutableInfo.put("cause", errorMessage)
-            info = mutableInfo.toMap()
+            resolveException(e)
         }
     }
 
     private fun getAliasOrUpdateInfo(): String? {
-        val alias = clusterService.state().metadata().index(managedIndexMetaData.index).getRolloverAlias()
+        val alias = clusterService.state().metadata().index(indexName).getRolloverAlias()
 
         if (alias == null) {
+            val message = getFailedNoValidAliasMessage(indexName)
+            logger.warn(message)
             stepStatus = StepStatus.FAILED
-            info = mapOf("message" to "There is no valid rollover_alias=$alias set on ${managedIndexMetaData.index}")
+            info = mapOf("message" to message)
         }
 
         return alias
@@ -158,32 +159,41 @@ class AttemptRolloverStep(
     private suspend fun getIndexStatsOrUpdateInfo(): IndicesStatsResponse? {
         try {
             val statsRequest = IndicesStatsRequest()
-                    .indices(managedIndexMetaData.index).clear().docs(true)
+                    .indices(indexName).clear().docs(true)
             val statsResponse: IndicesStatsResponse = client.admin().indices().suspendUntil { stats(statsRequest, it) }
 
             if (statsResponse.status == RestStatus.OK) {
                 return statsResponse
             }
 
-            logger.debug(
-                "Failed to get index stats for index: [${managedIndexMetaData.index}], status response: [${statsResponse.status}]"
-            )
-
+            val message = getFailedEvaluateMessage(indexName)
+            logger.warn("$message - ${statsResponse.status}")
             stepStatus = StepStatus.FAILED
             info = mapOf(
-                "message" to "Failed to evaluate conditions for rollover",
-                "shard_failures" to statsResponse.shardFailures.map { it.toString() }
+                "message" to message,
+                "shard_failures" to statsResponse.shardFailures.map { it.getUsefulCauseString() }
             )
         } catch (e: Exception) {
-            logger.error("Failed to evaluate conditions for rollover [index=${managedIndexMetaData.index}]", e)
+            val message = getFailedEvaluateMessage(indexName)
+            logger.error(message, e)
             stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to "Failed to evaluate conditions for rollover")
+            val mutableInfo = mutableMapOf("message" to message)
             val errorMessage = e.message
             if (errorMessage != null) mutableInfo["cause"] = errorMessage
             info = mutableInfo.toMap()
         }
 
         return null
+    }
+
+    private fun resolveException(e: Exception) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData {
@@ -193,5 +203,16 @@ class AttemptRolloverStep(
             transitionTo = null,
             info = info
         )
+    }
+
+    companion object {
+        fun getFailedMessage(index: String) = "Failed to rollover index [index=$index]"
+        fun getFailedAliasUpdateMessage(index: String, newIndex: String) =
+            "New index created, but failed to update alias [index=$index, newIndex=$newIndex]"
+        fun getFailedNoValidAliasMessage(index: String) = "Missing rollover_alias index setting [index=$index]"
+        fun getFailedDuplicateRollover(index: String) = "Index has already been rolled over [index=$index]"
+        fun getFailedEvaluateMessage(index: String) = "Failed to evaluate conditions for rollover [index=$index]"
+        fun getAttemptingMessage(index: String) = "Attempting to rollover index [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully rolled over index [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
@@ -89,27 +89,27 @@ class AttemptSnapshotStep(
         } catch (e: RemoteTransportException) {
             val cause = ExceptionsHelper.unwrapCause(e)
             if (cause is ConcurrentSnapshotExecutionException) {
-                resolveSnapshotException(cause)
+                handleSnapshotException(cause)
             } else {
-                resolveException(cause as Exception)
+                handleException(cause as Exception)
             }
         } catch (e: ConcurrentSnapshotExecutionException) {
-            resolveSnapshotException(e)
+            handleSnapshotException(e)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveSnapshotException(e: ConcurrentSnapshotExecutionException) {
+    private fun handleSnapshotException(e: ConcurrentSnapshotExecutionException) {
         val message = getFailedConcurrentSnapshotMessage(indexName)
         logger.debug(message, e)
         stepStatus = StepStatus.CONDITION_NOT_MET
         info = mapOf("message" to message)
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/AttemptSnapshotStep.kt
@@ -22,6 +22,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedi
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
 import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse
 import org.elasticsearch.client.Client
@@ -49,9 +50,8 @@ class AttemptSnapshotStep(
     override fun isIdempotent() = false
 
     @Suppress("TooGenericExceptionCaught", "ComplexMethod")
-    override suspend fun execute() {
+    override suspend fun execute(): AttemptSnapshotStep {
         try {
-            logger.info("Executing snapshot on ${managedIndexMetaData.index}")
             snapshotName = config
                     .snapshot
                     .plus("-")
@@ -62,7 +62,7 @@ class AttemptSnapshotStep(
 
             val createSnapshotRequest = CreateSnapshotRequest()
                     .userMetadata(mapOf("snapshot_created" to "Open Distro for Elasticsearch Index Management"))
-                    .indices(managedIndexMetaData.index)
+                    .indices(indexName)
                     .snapshot(snapshotName)
                     .repository(config.repository)
                     .waitForCompletion(false)
@@ -71,41 +71,46 @@ class AttemptSnapshotStep(
             when (response.status()) {
                 RestStatus.ACCEPTED -> {
                     stepStatus = StepStatus.COMPLETED
-                    mutableInfo["message"] = "Snapshot creation started for index: ${managedIndexMetaData.index}"
+                    mutableInfo["message"] = getSuccessMessage(indexName)
                 }
                 RestStatus.OK -> {
                     stepStatus = StepStatus.COMPLETED
-                    mutableInfo["message"] = "Snapshot created for index: ${managedIndexMetaData.index}"
+                    mutableInfo["message"] = getSuccessMessage(indexName)
                 }
                 else -> {
+                    val message = getFailedMessage(indexName)
+                    logger.warn("$message - $response")
                     stepStatus = StepStatus.FAILED
-                    mutableInfo["message"] = "There was an error during snapshot creation for index: ${managedIndexMetaData.index}"
+                    mutableInfo["message"] = getFailedMessage(indexName)
                     mutableInfo["cause"] = response.toString()
                 }
             }
             info = mutableInfo.toMap()
         } catch (e: RemoteTransportException) {
-            if (e.cause is ConcurrentSnapshotExecutionException) {
-                resolveSnapshotException(e.cause as ConcurrentSnapshotExecutionException)
+            val cause = ExceptionsHelper.unwrapCause(e)
+            if (cause is ConcurrentSnapshotExecutionException) {
+                resolveSnapshotException(cause)
             } else {
-                resolveException(e)
+                resolveException(cause as Exception)
             }
         } catch (e: ConcurrentSnapshotExecutionException) {
             resolveSnapshotException(e)
         } catch (e: Exception) {
             resolveException(e)
         }
+
+        return this
     }
 
     private fun resolveSnapshotException(e: ConcurrentSnapshotExecutionException) {
-        val message = "Snapshot creation already in progress."
+        val message = getFailedConcurrentSnapshotMessage(indexName)
         logger.debug(message, e)
         stepStatus = StepStatus.CONDITION_NOT_MET
         info = mapOf("message" to message)
     }
 
     private fun resolveException(e: Exception) {
-        val message = "Failed to create snapshot for index: ${managedIndexMetaData.index}"
+        val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED
         val mutableInfo = mutableMapOf("message" to message)
@@ -126,5 +131,8 @@ class AttemptSnapshotStep(
 
     companion object {
         const val name = "attempt_snapshot"
+        fun getFailedMessage(index: String) = "Failed to create snapshot [index=$index]"
+        fun getFailedConcurrentSnapshotMessage(index: String) = "Concurrent snapshot in progress, retrying next execution [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully started snapshot [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/WaitForSnapshotStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/WaitForSnapshotStep.kt
@@ -67,7 +67,7 @@ class WaitForSnapshotStep(
                         stepStatus = StepStatus.COMPLETED
                         info = mapOf("message" to getSuccessMessage(indexName), "state" to status.state.name)
                     }
-                    else -> { // State.FAILED, State.ABORTED, null
+                    else -> { // State.FAILED, State.ABORTED
                         val message = getFailedExistsMessage(indexName)
                         logger.warn(message)
                         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/WaitForSnapshotStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/WaitForSnapshotStep.kt
@@ -22,6 +22,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedi
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
 import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotStatus
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusRequest
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse
@@ -43,10 +44,9 @@ class WaitForSnapshotStep(
     override fun isIdempotent() = true
 
     @Suppress("ComplexMethod")
-    override suspend fun execute() {
+    override suspend fun execute(): WaitForSnapshotStep {
         try {
-            logger.info("Waiting for snapshot to complete...")
-            val snapshotName = getSnapshotName() ?: return
+            val snapshotName = getSnapshotName() ?: return this
             val request = SnapshotsStatusRequest()
                 .snapshots(arrayOf(snapshotName))
                 .repository(config.repository)
@@ -61,41 +61,42 @@ class WaitForSnapshotStep(
                 when (status.state) {
                     State.INIT, State.STARTED -> {
                         stepStatus = StepStatus.CONDITION_NOT_MET
-                        info = mapOf("message" to "Creating snapshot in progress for index: ${managedIndexMetaData.index}",
-                            "state" to status.state.name)
+                        info = mapOf("message" to getSnapshotInProgressMessage(indexName), "state" to status.state.name)
                     }
                     State.SUCCESS -> {
                         stepStatus = StepStatus.COMPLETED
-                        info = mapOf("message" to "Snapshot successfully created for index: ${managedIndexMetaData.index}",
-                            "state" to status.state.name)
+                        info = mapOf("message" to getSuccessMessage(indexName), "state" to status.state.name)
                     }
                     else -> { // State.FAILED, State.ABORTED, null
+                        val message = getFailedExistsMessage(indexName)
+                        logger.warn(message)
                         stepStatus = StepStatus.FAILED
-                        info = mapOf("message" to "Snapshot doesn't exist for index: ${managedIndexMetaData.index}",
-                            "state" to status.state.name)
+                        info = mapOf("message" to message, "state" to status.state.name)
                     }
                 }
             } else {
+                val message = getFailedExistsMessage(indexName)
+                logger.warn(message)
                 stepStatus = StepStatus.FAILED
-                info = mapOf("message" to "Snapshot doesn't exist for index: ${managedIndexMetaData.index}")
+                info = mapOf("message" to message)
             }
         } catch (e: RemoteTransportException) {
-            val message = "Failed to get status of snapshot for index: ${managedIndexMetaData.index}"
-            logger.error(message, e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to message)
-            val errorMessage = e.cause?.message
-            if (errorMessage != null) mutableInfo["cause"] = errorMessage
-            info = mutableInfo.toMap()
+            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            val message = "Failed to get status of snapshot for index: ${managedIndexMetaData.index}"
-            logger.error(message, e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to message)
-            val errorMessage = e.message
-            if (errorMessage != null) mutableInfo["cause"] = errorMessage
-            info = mutableInfo.toMap()
+            resolveException(e)
         }
+
+        return this
+    }
+
+    private fun resolveException(e: Exception) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     private fun getSnapshotName(): String? {
@@ -103,7 +104,7 @@ class WaitForSnapshotStep(
 
         if (actionProperties?.snapshotName == null) {
             stepStatus = StepStatus.FAILED
-            info = mapOf("message" to "Unable to retrieve [${ActionProperties.Properties.SNAPSHOT_NAME.key}] from ActionProperties=$actionProperties")
+            info = mapOf("message" to getFailedActionPropertiesMessage(indexName, actionProperties))
             return null
         }
 
@@ -120,5 +121,11 @@ class WaitForSnapshotStep(
 
     companion object {
         const val name = "wait_for_snapshot"
+        fun getFailedMessage(index: String) = "Failed to get status of snapshot [index=$index]"
+        fun getFailedExistsMessage(index: String) = "Snapshot doesn't exist [index=$index]"
+        fun getFailedActionPropertiesMessage(index: String, actionProperties: ActionProperties?) =
+            "Unable to retrieve [${ActionProperties.Properties.SNAPSHOT_NAME.key}] from ActionProperties=$actionProperties [index=$index]"
+        fun getSuccessMessage(index: String) = "Successfully created snapshot [index=$index]"
+        fun getSnapshotInProgressMessage(index: String) = "Snapshot currently in progress [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/WaitForSnapshotStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/snapshot/WaitForSnapshotStep.kt
@@ -81,15 +81,15 @@ class WaitForSnapshotStep(
                 info = mapOf("message" to message)
             }
         } catch (e: RemoteTransportException) {
-            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
+            handleException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/transition/AttemptTransitionStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/transition/AttemptTransitionStep.kt
@@ -90,9 +90,8 @@ class AttemptTransitionStep(
                     )
                     return this
                 }
-
-                numDocs = statsResponse.primaries.docs?.count ?: 0
-                indexSize = ByteSizeValue(statsResponse.primaries.docs?.totalSizeInBytes ?: 0)
+                numDocs = statsResponse.primaries.getDocs()?.count ?: 0
+                indexSize = ByteSizeValue(statsResponse.primaries.getDocs()?.totalSizeInBytes ?: 0)
             }
 
             // Find the first transition that evaluates to true and get the state to transition to, otherwise return null if none are true

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/transition/AttemptTransitionStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/transition/AttemptTransitionStep.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.step.transition
 
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.getUsefulCauseString
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.elasticapi.suspendUntil
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.TransitionsActionConfig
@@ -23,14 +24,16 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.Step
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.evaluateConditions
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.hasStatsConditions
 import org.apache.logging.log4j.LogManager
+import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse
 import org.elasticsearch.client.Client
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.common.unit.ByteSizeValue
 import org.elasticsearch.rest.RestStatus
-import java.lang.Exception
+import org.elasticsearch.transport.RemoteTransportException
 import java.time.Instant
+import kotlin.Exception
 
 /**
  * Attempt to transition to the next state
@@ -53,21 +56,20 @@ class AttemptTransitionStep(
 
     override fun isIdempotent() = true
 
-    @Suppress("TooGenericExceptionCaught")
-    override suspend fun execute() {
-        val index = managedIndexMetaData.index
+    @Suppress("TooGenericExceptionCaught", "ReturnCount", "ComplexMethod")
+    override suspend fun execute(): AttemptTransitionStep {
         try {
             if (config.transitions.isEmpty()) {
-                logger.info("$index transitions are empty, completing policy")
+                logger.info("$indexName transitions are empty, completing policy")
                 policyCompleted = true
                 stepStatus = StepStatus.COMPLETED
-                return
+                return this
             }
 
-            val indexCreationDate = clusterService.state().metadata().index(index).creationDate
+            val indexCreationDate = clusterService.state().metadata().index(indexName).creationDate
             val indexCreationDateInstant = Instant.ofEpochMilli(indexCreationDate)
             if (indexCreationDate == -1L) {
-                logger.warn("$index had an indexCreationDate=-1L, cannot use for comparison")
+                logger.warn("$indexName had an indexCreationDate=-1L, cannot use for comparison")
             }
             val stepStartTime = getStepStartTime()
             var numDocs: Long? = null
@@ -75,20 +77,18 @@ class AttemptTransitionStep(
 
             if (config.transitions.any { it.hasStatsConditions() }) {
                 val statsRequest = IndicesStatsRequest()
-                    .indices(index).clear().docs(true)
+                    .indices(indexName).clear().docs(true)
                 val statsResponse: IndicesStatsResponse = client.admin().indices().suspendUntil { stats(statsRequest, it) }
 
                 if (statsResponse.status != RestStatus.OK) {
-                    logger.debug(
-                        "Failed to get index stats for index: [$index], status response: [${statsResponse.status}]"
-                    )
-
+                    val message = getFailedStatsMessage(indexName)
+                    logger.warn("$message - ${statsResponse.status}")
                     stepStatus = StepStatus.FAILED
                     info = mapOf(
-                        "message" to "Failed to evaluate conditions for transition",
-                        "shard_failures" to statsResponse.shardFailures.map { it.toString() }
+                        "message" to message,
+                        "shard_failures" to statsResponse.shardFailures.map { it.getUsefulCauseString() }
                     )
-                    return
+                    return this
                 }
 
                 numDocs = statsResponse.primaries.docs?.count ?: 0
@@ -98,24 +98,34 @@ class AttemptTransitionStep(
             // Find the first transition that evaluates to true and get the state to transition to, otherwise return null if none are true
             stateName = config.transitions.find { it.evaluateConditions(indexCreationDateInstant, numDocs, indexSize, stepStartTime) }?.stateName
             val message: String
+            val stateName = stateName // shadowed on purpose to prevent var from changing
             if (stateName != null) {
-                logger.info("$index transition conditions evaluated to true [indexCreationDate=$indexCreationDate," +
+                logger.info("$indexName transition conditions evaluated to true [indexCreationDate=$indexCreationDate," +
                         " numDocs=$numDocs, indexSize=${indexSize?.bytes},stepStartTime=${stepStartTime.toEpochMilli()}]")
                 stepStatus = StepStatus.COMPLETED
-                message = "Transitioning to $stateName"
+                message = getSuccessMessage(indexName, stateName)
             } else {
                 stepStatus = StepStatus.CONDITION_NOT_MET
-                message = "Attempting to transition"
+                message = getEvaluatingMessage(indexName)
             }
             info = mapOf("message" to message)
+        } catch (e: RemoteTransportException) {
+            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            logger.error("Failed to transition index [index=$index]", e)
-            stepStatus = StepStatus.FAILED
-            val mutableInfo = mutableMapOf("message" to "Failed to transition index")
-            val errorMessage = e.message
-            if (errorMessage != null) mutableInfo["cause"] = errorMessage
-            info = mutableInfo.toMap()
+            resolveException(e)
         }
+
+        return this
+    }
+
+    private fun resolveException(e: Exception) {
+        val message = getFailedMessage(indexName)
+        logger.error(message, e)
+        stepStatus = StepStatus.FAILED
+        val mutableInfo = mutableMapOf("message" to message)
+        val errorMessage = e.message
+        if (errorMessage != null) mutableInfo["cause"] = errorMessage
+        info = mutableInfo.toMap()
     }
 
     override fun getUpdatedManagedIndexMetaData(currentMetaData: ManagedIndexMetaData): ManagedIndexMetaData {
@@ -125,5 +135,12 @@ class AttemptTransitionStep(
             stepMetaData = StepMetaData(name, getStepStartTime().toEpochMilli(), stepStatus),
             info = info
         )
+    }
+
+    companion object {
+        fun getFailedMessage(index: String) = "Failed to transition index [index=$index]"
+        fun getFailedStatsMessage(index: String) = "Failed to get stats information for the index [index=$index]"
+        fun getEvaluatingMessage(index: String) = "Evaluating transition conditions [index=$index]"
+        fun getSuccessMessage(index: String, state: String) = "Transitioning to $state [index=$index]"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/transition/AttemptTransitionStep.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/transition/AttemptTransitionStep.kt
@@ -109,15 +109,15 @@ class AttemptTransitionStep(
             }
             info = mapOf("message" to message)
         } catch (e: RemoteTransportException) {
-            resolveException(ExceptionsHelper.unwrapCause(e) as Exception)
+            handleException(ExceptionsHelper.unwrapCause(e) as Exception)
         } catch (e: Exception) {
-            resolveException(e)
+            handleException(e)
         }
 
         return this
     }
 
-    private fun resolveException(e: Exception) {
+    private fun handleException(e: Exception) {
         val message = getFailedMessage(indexName)
         logger.error(message, e)
         stepStatus = StepStatus.FAILED

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/IndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/util/IndexUtils.kt
@@ -48,6 +48,7 @@ class IndexUtils {
             indexManagementHistorySchemaVersion = getSchemaVersion(IndexStateManagementIndices.indexStateManagementHistoryMappings)
         }
 
+        @Suppress("NestedBlockDepth")
         fun getSchemaVersion(mapping: String): Long {
             val xcp = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY,
                 LoggingDeprecationHandler.INSTANCE, mapping)
@@ -120,6 +121,7 @@ class IndexUtils {
         }
 
         @OpenForTesting
+        @Suppress("LongParameterList")
         fun checkAndUpdateIndexMapping(
             index: String,
             schemaVersion: Long,
@@ -142,6 +144,7 @@ class IndexUtils {
         }
 
         @OpenForTesting
+        @Suppress("LongParameterList")
         fun checkAndUpdateAliasMapping(
             alias: String,
             schemaVersion: Long,

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/TestHelpers.kt
@@ -20,6 +20,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ChangePo
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Conditions
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ErrorNotification
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.State
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.StateFilter
@@ -386,6 +387,11 @@ fun ChangePolicy.toJsonString(): String {
 fun ManagedIndexConfig.toJsonString(): String {
     val builder = XContentFactory.jsonBuilder()
     return this.toXContent(builder, ToXContent.EMPTY_PARAMS).string()
+}
+
+fun ManagedIndexMetaData.toJsonString(): String {
+    val builder = XContentFactory.jsonBuilder().startObject()
+    return this.toXContent(builder, ToXContent.EMPTY_PARAMS).endObject().string()
 }
 
 fun SnapshotActionConfig.toJsonString(): String {

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionRetryIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionRetryIT.kt
@@ -21,6 +21,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedi
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.PolicyRetryInfoMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StateMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.rollover.AttemptRolloverStep
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.waitFor
 import java.time.Instant
 import java.util.Locale
@@ -42,7 +43,7 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
         val indexName = "${testIndexName}_index_1"
         val policyID = "${testIndexName}_testPolicyName_1"
         createPolicyJson(testPolicy, policyID)
-        val expectedInfoString = mapOf("message" to "There is no valid rollover_alias=null set on $indexName").toString()
+        val expectedInfoString = mapOf("message" to AttemptRolloverStep.getFailedNoValidAliasMessage(indexName)).toString()
 
         createIndex(indexName, policyID)
 
@@ -135,7 +136,7 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
 
         // even if we ran couple times we should have backed off and only retried once.
         waitFor {
-            val expectedInfoString = mapOf("message" to "There is no valid rollover_alias=null set on $indexName").toString()
+            val expectedInfoString = mapOf("message" to AttemptRolloverStep.getFailedNoValidAliasMessage(indexName)).toString()
             assertPredicatesOnMetaData(
                 listOf(
                     indexName to listOf(

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionTimeoutIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/ActionTimeoutIT.kt
@@ -19,6 +19,8 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateMana
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.ActionMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.open.AttemptOpenStep
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.rollover.AttemptRolloverStep
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.waitFor
 import org.hamcrest.collection.IsMapContaining
 import java.time.Instant
@@ -59,7 +61,7 @@ class ActionTimeoutIT : IndexStateManagementRestTestCase() {
             assertThat(
                 "Should be attempting to rollover",
                 getExplainManagedIndexMetaData(indexName).info,
-                IsMapContaining.hasEntry("message", "Attempting to rollover" as Any?)
+                IsMapContaining.hasEntry("message", AttemptRolloverStep.getAttemptingMessage(indexName) as Any?)
             )
         }
 
@@ -106,7 +108,7 @@ class ActionTimeoutIT : IndexStateManagementRestTestCase() {
         // the second execution we move into open action, we won't hit the timeout as this is the execution that sets the startTime
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
-        val expectedOpenInfoString = mapOf("message" to "Successfully opened index").toString()
+        val expectedOpenInfoString = mapOf("message" to AttemptOpenStep.getSuccessMessage(indexName)).toString()
         waitFor {
             assertPredicatesOnMetaData(
                 listOf(indexName to listOf(ManagedIndexMetaData.INFO to fun(info: Any?): Boolean = expectedOpenInfoString == info.toString())),
@@ -125,7 +127,7 @@ class ActionTimeoutIT : IndexStateManagementRestTestCase() {
             assertThat(
                 "Should be attempting to rollover",
                 getExplainManagedIndexMetaData(indexName).info,
-                IsMapContaining.hasEntry("message", "Attempting to rollover" as Any?)
+                IsMapContaining.hasEntry("message", AttemptRolloverStep.getAttemptingMessage(indexName) as Any?)
             )
         }
     }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/AllocationActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/AllocationActionIT.kt
@@ -20,6 +20,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.State
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.AllocationActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomErrorNotification
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.allocation.AttemptAllocationStep
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.waitFor
 import org.junit.Assume
 import java.time.Instant
@@ -253,7 +254,7 @@ class AllocationActionIT : IndexStateManagementRestTestCase() {
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
         waitFor {
-            assertEquals("Failed to update settings with allocation.", getExplainManagedIndexMetaData(indexName).info?.get("message"))
+            assertEquals(AttemptAllocationStep.getFailedMessage(indexName), getExplainManagedIndexMetaData(indexName).info?.get("message"))
         }
     }
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/IndexStateManagementHistoryIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/IndexStateManagementHistoryIT.kt
@@ -27,6 +27,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedi
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.StateMetaData
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomErrorNotification
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.readonly.SetReadOnlyStep
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.waitFor
 import org.elasticsearch.action.search.SearchResponse
 import java.time.Instant
@@ -91,7 +92,7 @@ class IndexStateManagementHistoryIT : IndexStateManagementRestTestCase() {
             actionMetaData = ActionMetaData(ActionConfig.ActionType.READ_ONLY.toString(), actualHistory.actionMetaData!!.startTime, 0, false, 0, 0, null),
             stepMetaData = null,
             policyRetryInfo = PolicyRetryInfoMetaData(false, 0),
-            info = mapOf("message" to "Set index to read-only")
+            info = mapOf("message" to SetReadOnlyStep.getSuccessMessage(indexName))
         )
 
         assertEquals(expectedHistory, actualHistory)
@@ -157,7 +158,7 @@ class IndexStateManagementHistoryIT : IndexStateManagementRestTestCase() {
             actionMetaData = ActionMetaData(ActionConfig.ActionType.READ_ONLY.toString(), actualHistory.actionMetaData!!.startTime, 0, false, 0, 0, null),
             stepMetaData = null,
             policyRetryInfo = PolicyRetryInfoMetaData(false, 0),
-            info = mapOf("message" to "Set index to read-only")
+            info = mapOf("message" to SetReadOnlyStep.getSuccessMessage(indexName))
         )
 
         assertEquals(expectedHistory, actualHistory)
@@ -223,7 +224,7 @@ class IndexStateManagementHistoryIT : IndexStateManagementRestTestCase() {
             actionMetaData = ActionMetaData(ActionConfig.ActionType.READ_ONLY.toString(), actualHistory.actionMetaData!!.startTime, 0, false, 0, 0, null),
             stepMetaData = null,
             policyRetryInfo = PolicyRetryInfoMetaData(false, 0),
-            info = mapOf("message" to "Set index to read-only")
+            info = mapOf("message" to SetReadOnlyStep.getSuccessMessage(indexName))
         )
 
         assertEquals(expectedHistory, actualHistory)
@@ -313,7 +314,7 @@ class IndexStateManagementHistoryIT : IndexStateManagementRestTestCase() {
             actionMetaData = ActionMetaData(ActionConfig.ActionType.READ_ONLY.toString(), actualHistory1.actionMetaData!!.startTime, 0, false, 0, 0, null),
             stepMetaData = null,
             policyRetryInfo = PolicyRetryInfoMetaData(false, 0),
-            info = mapOf("message" to "Set index to read-only")
+            info = mapOf("message" to SetReadOnlyStep.getSuccessMessage(indexName))
         )
 
         assertEquals(expectedHistory1, actualHistory1)

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/RolloverActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/RolloverActionIT.kt
@@ -20,6 +20,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.State
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.RolloverActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomErrorNotification
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.rollover.AttemptRolloverStep
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.waitFor
 import org.elasticsearch.common.unit.ByteSizeUnit
 import org.elasticsearch.common.unit.ByteSizeValue
@@ -66,7 +67,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor {
             val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
-            assertEquals("Index did not rollover.", "Rolled over index", info["message"])
+            assertEquals("Index did not rollover.", AttemptRolloverStep.getSuccessMessage(firstIndex), info["message"])
             assertNull("Should not have conditions if none specified", info["conditions"])
         }
         Assert.assertTrue("New rollover index does not exist.", indexExists("$indexNameBase-000002"))
@@ -104,7 +105,8 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor {
             val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
-            assertEquals("Index rollover before it met the condition.", "Attempting to rollover", info["message"])
+            assertEquals("Index rollover before it met the condition.",
+                AttemptRolloverStep.getAttemptingMessage(firstIndex), info["message"])
             val conditions = info["conditions"] as Map<String, Any?>
             assertEquals("Did not have exclusively min size and min doc count conditions",
                     setOf(RolloverActionConfig.MIN_SIZE_FIELD, RolloverActionConfig.MIN_DOC_COUNT_FIELD), conditions.keys)
@@ -122,7 +124,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor {
             val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
-            assertEquals("Index did not rollover", "Rolled over index", info["message"])
+            assertEquals("Index did not rollover", AttemptRolloverStep.getSuccessMessage(firstIndex), info["message"])
             val conditions = info["conditions"] as Map<String, Any?>
             assertEquals("Did not have exclusively min size and min doc count conditions",
                     setOf(RolloverActionConfig.MIN_SIZE_FIELD, RolloverActionConfig.MIN_DOC_COUNT_FIELD), conditions.keys)
@@ -168,7 +170,8 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor {
             val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
-            assertEquals("Index rollover before it met the condition.", "Attempting to rollover", info["message"])
+            assertEquals("Index rollover before it met the condition.",
+                AttemptRolloverStep.getAttemptingMessage(firstIndex), info["message"])
             val conditions = info["conditions"] as Map<String, Any?>
             assertEquals("Did not have exclusively min age and min doc count conditions",
                     setOf(RolloverActionConfig.MIN_INDEX_AGE_FIELD, RolloverActionConfig.MIN_DOC_COUNT_FIELD), conditions.keys)
@@ -186,7 +189,7 @@ class RolloverActionIT : IndexStateManagementRestTestCase() {
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor {
             val info = getExplainManagedIndexMetaData(firstIndex).info as Map<String, Any?>
-            assertEquals("Index did not rollover", "Rolled over index", info["message"])
+            assertEquals("Index did not rollover", AttemptRolloverStep.getSuccessMessage(firstIndex), info["message"])
             val conditions = info["conditions"] as Map<String, Any?>
             assertEquals("Did not have exclusively min age and min doc count conditions",
                     setOf(RolloverActionConfig.MIN_INDEX_AGE_FIELD, RolloverActionConfig.MIN_DOC_COUNT_FIELD), conditions.keys)

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/SnapshotActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/SnapshotActionIT.kt
@@ -20,6 +20,8 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.State
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.SnapshotActionConfig
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomErrorNotification
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.snapshot.AttemptSnapshotStep
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.snapshot.WaitForSnapshotStep
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.waitFor
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -99,11 +101,11 @@ class SnapshotActionIT : IndexStateManagementRestTestCase() {
 
         // Change the start time so attempt snapshot step with execute
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Snapshot creation started for index: $indexName", getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+        waitFor { assertEquals(AttemptSnapshotStep.getSuccessMessage(indexName), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
 
         // Change the start time so wait for snapshot step will execute
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Snapshot successfully created for index: $indexName", getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+        waitFor { assertEquals(WaitForSnapshotStep.getSuccessMessage(indexName), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
 
         // verify we set snapshotName in action properties
         waitFor {
@@ -148,7 +150,7 @@ class SnapshotActionIT : IndexStateManagementRestTestCase() {
 
         // Change the start time so attempt snapshot step with execute
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Snapshot creation started for index: $indexName", getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+        waitFor { assertEquals(AttemptSnapshotStep.getSuccessMessage(indexName), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
 
         // Confirm successful snapshot creation
         waitFor { assertSnapshotExists(repository, snapshot) }
@@ -162,7 +164,7 @@ class SnapshotActionIT : IndexStateManagementRestTestCase() {
         // Change the start time so wait for snapshot step will execute where we should see a missing snapshot exception
         updateManagedIndexConfigStartTime(managedIndexConfig)
         waitFor {
-            assertEquals("Failed to get status of snapshot for index: $indexName", getExplainManagedIndexMetaData(indexName).info?.get("message"))
+            assertEquals(WaitForSnapshotStep.getFailedMessage(indexName), getExplainManagedIndexMetaData(indexName).info?.get("message"))
             assertEquals("[$repository:$snapshotName] is missing", getExplainManagedIndexMetaData(indexName).info?.get("cause"))
         }
     }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/TransitionActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/action/TransitionActionIT.kt
@@ -1,0 +1,63 @@
+package com.amazon.opendistroforelasticsearch.indexstatemanagement.action
+
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateManagementRestTestCase
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Conditions
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Policy
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.State
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Transition
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomErrorNotification
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.transition.AttemptTransitionStep
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.waitFor
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+class TransitionActionIT : IndexStateManagementRestTestCase() {
+
+    private val testIndexName = javaClass.simpleName.toLowerCase(Locale.ROOT)
+
+    fun `test doc count condition`() {
+        val indexName = "${testIndexName}_index_1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+        val secondStateName = "second"
+        val states = listOf(
+            State("first", listOf(), listOf(Transition(secondStateName, Conditions(docCount = 5L)))),
+            State(secondStateName, listOf(), listOf())
+        )
+
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        createIndex(indexName, policyID)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+
+        // Initializing the policy/metadata
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+
+        // Evaluating transition conditions for first time
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        // Should not have evaluated to true
+        waitFor { assertEquals(AttemptTransitionStep.getEvaluatingMessage(indexName), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+
+        // Add 6 documents (>5)
+        insertSampleData(indexName, 6)
+
+        // Evaluating transition conditions for second time
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        // Should have evaluated to true
+        waitFor { assertEquals(AttemptTransitionStep.getSuccessMessage(indexName, secondStateName), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/XContentTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/model/XContentTests.kt
@@ -196,6 +196,27 @@ class XContentTests : ESTestCase() {
         assertEquals("Round tripping ManagedIndexConfig doesn't work with id and version", configThree, parsedConfigThree)
     }
 
+    fun `test managed index metadata parsing`() {
+        val metadata = ManagedIndexMetaData(
+            index = randomAlphaOfLength(10),
+            indexUuid = randomAlphaOfLength(10),
+            policyID = randomAlphaOfLength(10),
+            policySeqNo = randomNonNegativeLong(),
+            policyPrimaryTerm = randomNonNegativeLong(),
+            policyCompleted = null,
+            rolledOver = null,
+            transitionTo = randomAlphaOfLength(10),
+            stateMetaData = null,
+            actionMetaData = null,
+            stepMetaData = null,
+            policyRetryInfo = null,
+            info = null
+        )
+        val metadataString = metadata.toJsonString()
+        val parsedMetaData = ManagedIndexMetaData.parse(parser(metadataString))
+        assertEquals("Round tripping ManagedIndexMetaData doesn't work", metadata, parsedMetaData)
+    }
+
     fun `test change policy parsing`() {
         val changePolicy = randomChangePolicy()
 

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -34,6 +34,7 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomReplicaC
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomState
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.resthandler.RestChangePolicyAction.Companion.INDEX_NOT_MANAGED
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.rollover.AttemptRolloverStep
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.FAILED_INDICES
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.FAILURES
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.util.UPDATED_INDICES
@@ -536,7 +537,8 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         // verify we are in rollover and have not completed it yet
         waitFor {
             assertEquals(ActionConfig.ActionType.ROLLOVER.type, getExplainManagedIndexMetaData(indexName).actionMetaData?.name)
-            assertEquals("Attempting to rollover", getExplainManagedIndexMetaData(indexName).info?.get("message"))
+            assertEquals(AttemptRolloverStep.getAttemptingMessage(indexName),
+                getExplainManagedIndexMetaData(indexName).info?.get("message"))
         }
 
         val newStateWithReadOnlyAction = randomState(name = stateWithReadOnlyAction.name, actions = listOf(actionConfig.copy(minDocs = 5)))
@@ -569,7 +571,8 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         // which should now actually rollover because 5 docs is less than 10 docs
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
-        waitFor { assertEquals("Rolled over index", getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+        waitFor { assertEquals(AttemptRolloverStep.getSuccessMessage(indexName),
+            getExplainManagedIndexMetaData(indexName).info?.get("message")) }
     }
 
     fun `test changing failed init policy`() {

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
@@ -254,7 +254,7 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
             )
         }
 
-        // speed up to execute first action, readonly
+        // speed up to execute set read only force merge step
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
         waitFor {
@@ -271,7 +271,7 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
         // close the index to cause next execution to fail
         closeIndex(indexName)
 
-        // speed up to execute first action and fail, call force merge
+        // speed up to execute attempt call force merge step
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
         // verify failed and save the startTime

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/runner/ManagedIndexRunnerIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/runner/ManagedIndexRunnerIT.kt
@@ -29,6 +29,9 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomReadWrit
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomState
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.randomTransition
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.readonly.SetReadOnlyStep
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.readwrite.SetReadWriteStep
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.transition.AttemptTransitionStep
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.waitFor
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule.IntervalSchedule
 import java.time.Instant
@@ -130,19 +133,19 @@ class ManagedIndexRunnerIT : IndexStateManagementRestTestCase() {
 
         // speed up to first execution that should set index to read only
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Set index to read-only", getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+        waitFor { assertEquals(SetReadOnlyStep.getSuccessMessage(indexName), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
 
         // speed up to second execution that should transition to second_state
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Transitioning to second_state", getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+        waitFor { assertEquals(AttemptTransitionStep.getSuccessMessage(indexName, secondState.name), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
 
         // speed up to third execution that should set index back to read write
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Set index to read-write", getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+        waitFor { assertEquals(SetReadWriteStep.getSuccessMessage(indexName), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
 
         // speed up to fourth execution that should transition to first_state
         updateManagedIndexConfigStartTime(managedIndexConfig)
-        waitFor { assertEquals("Transitioning to first_state", getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+        waitFor { assertEquals(AttemptTransitionStep.getSuccessMessage(indexName, firstState.name), getExplainManagedIndexMetaData(indexName).info?.get("message")) }
 
         // remove read_only from the allowlist
         val allowedActions = ActionConfig.ActionType.values().toList()

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/AttemptOpenStepTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/AttemptOpenStepTests.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexstatemanagement.step
+
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.OpenActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.open.AttemptOpenStep
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
+import org.elasticsearch.action.ActionListener
+import org.elasticsearch.action.admin.indices.open.OpenIndexResponse
+import org.elasticsearch.client.AdminClient
+import org.elasticsearch.client.Client
+import org.elasticsearch.client.IndicesAdminClient
+import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.test.ESTestCase
+import org.elasticsearch.transport.RemoteTransportException
+
+class AttemptOpenStepTests : ESTestCase() {
+
+    private val clusterService: ClusterService = mock()
+
+    fun `test open step sets step status to failed when not acknowledged`() {
+        val openIndexResponse = OpenIndexResponse(false, false)
+        val client = getClient(getAdminClient(getIndicesAdminClient(openIndexResponse, null)))
+
+        runBlocking {
+            val openActionConfig = OpenActionConfig(0)
+            val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
+            val attemptOpenStep = AttemptOpenStep(clusterService, client, openActionConfig, managedIndexMetaData)
+            attemptOpenStep.execute()
+            val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+        }
+    }
+
+    fun `test open step sets step status to failed when error thrown`() {
+        val exception = IllegalArgumentException("example")
+        val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
+
+        runBlocking {
+            val openActionConfig = OpenActionConfig(0)
+            val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
+            val attemptOpenStep = AttemptOpenStep(clusterService, client, openActionConfig, managedIndexMetaData)
+            attemptOpenStep.execute()
+            val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+        }
+    }
+
+    fun `test open step remote transport exception`() {
+        val exception = RemoteTransportException("rte", IllegalArgumentException("nested"))
+        val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
+
+        runBlocking {
+            val openActionConfig = OpenActionConfig(0)
+            val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
+            val attemptOpenStep = AttemptOpenStep(clusterService, client, openActionConfig, managedIndexMetaData)
+            attemptOpenStep.execute()
+            val updatedManagedIndexMetaData = attemptOpenStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get cause from nested exception", "nested", updatedManagedIndexMetaData.info!!["cause"])
+        }
+    }
+
+    private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
+    private fun getAdminClient(indicesAdminClient: IndicesAdminClient): AdminClient = mock { on { indices() } doReturn indicesAdminClient }
+    private fun getIndicesAdminClient(openIndexResponse: OpenIndexResponse?, exception: Exception?): IndicesAdminClient {
+        assertTrue("Must provide one and only one response or exception", (openIndexResponse != null).xor(exception != null))
+        return mock {
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<OpenIndexResponse>>(1)
+                if (openIndexResponse != null) listener.onResponse(openIndexResponse)
+                else listener.onFailure(exception)
+            }.whenever(this.mock).open(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/AttemptSetReplicaCountStepTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/AttemptSetReplicaCountStepTests.kt
@@ -16,8 +16,8 @@
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.step
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.IndexPriorityActionConfig
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.indexpriority.AttemptSetIndexPriorityStep
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ReplicaCountActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.replicacount.AttemptSetReplicaCountStep
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
@@ -32,66 +32,49 @@ import org.elasticsearch.client.IndicesAdminClient
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.test.ESTestCase
 import org.elasticsearch.transport.RemoteTransportException
-import kotlin.IllegalArgumentException
 
-class AttemptSetIndexPriorityStepTests : ESTestCase() {
+class AttemptSetReplicaCountStepTests : ESTestCase() {
 
     private val clusterService: ClusterService = mock()
 
-    fun `test set priority step sets step status to completed when successful`() {
-        val acknowledgedResponse = AcknowledgedResponse(true)
-        val client = getClient(getAdminClient(getIndicesAdminClient(acknowledgedResponse, null)))
+    fun `test replica step sets step status to failed when not acknowledged`() {
+        val replicaCountResponse = AcknowledgedResponse(false)
+        val client = getClient(getAdminClient(getIndicesAdminClient(replicaCountResponse, null)))
 
         runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
+            val replicaCountActionConfig = ReplicaCountActionConfig(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
-            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
-        }
-    }
-
-    fun `test set priority step sets step status to failed when not acknowledged`() {
-        val acknowledgedResponse = AcknowledgedResponse(false)
-        val client = getClient(getAdminClient(getIndicesAdminClient(acknowledgedResponse, null)))
-
-        runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
-            val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            val replicaCountStep = AttemptSetReplicaCountStep(clusterService, client, replicaCountActionConfig, managedIndexMetaData)
+            replicaCountStep.execute()
+            val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
         }
     }
 
-    fun `test set priority step sets step status to failed when error thrown`() {
+    fun `test replica step sets step status to failed when error thrown`() {
         val exception = IllegalArgumentException("example")
         val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
 
         runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
+            val replicaCountActionConfig = ReplicaCountActionConfig(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
-            logger.info(updatedManagedIndexMetaData)
+            val replicaCountStep = AttemptSetReplicaCountStep(clusterService, client, replicaCountActionConfig, managedIndexMetaData)
+            replicaCountStep.execute()
+            val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
         }
     }
 
-    fun `test set priority step sets step status to failed when remote transport error thrown`() {
+    fun `test replica step sets step status to failed when remote transport error thrown`() {
         val exception = RemoteTransportException("rte", IllegalArgumentException("nested"))
         val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
 
         runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
+            val replicaCountActionConfig = ReplicaCountActionConfig(2, 0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
-            logger.info(updatedManagedIndexMetaData)
+            val replicaCountStep = AttemptSetReplicaCountStep(clusterService, client, replicaCountActionConfig, managedIndexMetaData)
+            replicaCountStep.execute()
+            val updatedManagedIndexMetaData = replicaCountStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
             assertEquals("Did not get cause from nested exception", "nested", updatedManagedIndexMetaData.info!!["cause"])
         }
@@ -99,12 +82,12 @@ class AttemptSetIndexPriorityStepTests : ESTestCase() {
 
     private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
     private fun getAdminClient(indicesAdminClient: IndicesAdminClient): AdminClient = mock { on { indices() } doReturn indicesAdminClient }
-    private fun getIndicesAdminClient(acknowledgedResponse: AcknowledgedResponse?, exception: Exception?): IndicesAdminClient {
-        assertTrue("Must provide one and only one response or exception", (acknowledgedResponse != null).xor(exception != null))
+    private fun getIndicesAdminClient(replicaResponse: AcknowledgedResponse?, exception: Exception?): IndicesAdminClient {
+        assertTrue("Must provide one and only one response or exception", (replicaResponse != null).xor(exception != null))
         return mock {
             doAnswer { invocationOnMock ->
                 val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(1)
-                if (acknowledgedResponse != null) listener.onResponse(acknowledgedResponse)
+                if (replicaResponse != null) listener.onResponse(replicaResponse)
                 else listener.onFailure(exception)
             }.whenever(this.mock).updateSettings(any(), any())
         }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/AttemptSnapshotStepTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/AttemptSnapshotStepTests.kt
@@ -1,0 +1,120 @@
+package com.amazon.opendistroforelasticsearch.indexstatemanagement.step
+
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.SnapshotActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.ActionMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.ActionProperties
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.snapshot.AttemptSnapshotStep
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
+import org.elasticsearch.action.ActionListener
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse
+import org.elasticsearch.client.AdminClient
+import org.elasticsearch.client.Client
+import org.elasticsearch.client.ClusterAdminClient
+import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.rest.RestStatus
+import org.elasticsearch.snapshots.ConcurrentSnapshotExecutionException
+import org.elasticsearch.test.ESTestCase
+import org.elasticsearch.transport.RemoteTransportException
+
+class AttemptSnapshotStepTests : ESTestCase() {
+
+    private val clusterService: ClusterService = mock()
+    private val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+    private val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(AttemptSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
+
+    fun `test snapshot response when block`() {
+        val response: CreateSnapshotResponse = mock()
+        val client = getClient(getAdminClient(getClusterAdminClient(response, null)))
+
+        whenever(response.status()).doReturn(RestStatus.ACCEPTED)
+        runBlocking {
+            val step = AttemptSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+        }
+
+        whenever(response.status()).doReturn(RestStatus.OK)
+        runBlocking {
+            val step = AttemptSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+        }
+
+        whenever(response.status()).doReturn(RestStatus.INTERNAL_SERVER_ERROR)
+        runBlocking {
+            val step = AttemptSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+        }
+    }
+
+    fun `test snapshot exception`() {
+        val exception = IllegalArgumentException("example")
+        val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
+        runBlocking {
+            val step = AttemptSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get cause from nested exception", "example", updatedManagedIndexMetaData.info!!["cause"])
+        }
+    }
+
+    fun `test snapshot concurrent snapshot exception`() {
+        val exception = ConcurrentSnapshotExecutionException("repo", "other-snapshot", "concurrent snapshot in progress")
+        val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
+        runBlocking {
+            val step = AttemptSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get failed concurrent message", AttemptSnapshotStep.getFailedConcurrentSnapshotMessage("test"), updatedManagedIndexMetaData.info!!["message"])
+        }
+    }
+
+    fun `test snapshot remote transport concurrent exception`() {
+        val exception = RemoteTransportException("rte", ConcurrentSnapshotExecutionException("repo", "other-snapshot", "concurrent snapshot in progress"))
+        val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
+        runBlocking {
+            val step = AttemptSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get failed concurrent message", AttemptSnapshotStep.getFailedConcurrentSnapshotMessage("test"), updatedManagedIndexMetaData.info!!["message"])
+        }
+    }
+
+    fun `test snapshot remote transport normal exception`() {
+        val exception = RemoteTransportException("rte", IllegalArgumentException("some error"))
+        val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
+        runBlocking {
+            val step = AttemptSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get cause from nested exception", "some error", updatedManagedIndexMetaData.info!!["cause"])
+        }
+    }
+
+    private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
+    private fun getAdminClient(clusterAdminClient: ClusterAdminClient): AdminClient = mock { on { cluster() } doReturn clusterAdminClient }
+    private fun getClusterAdminClient(createSnapshotRequest: CreateSnapshotResponse?, exception: Exception?): ClusterAdminClient {
+        assertTrue("Must provide one and only one response or exception", (createSnapshotRequest != null).xor(exception != null))
+        return mock {
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<CreateSnapshotResponse>>(1)
+                if (createSnapshotRequest != null) listener.onResponse(createSnapshotRequest)
+                else listener.onFailure(exception)
+            }.whenever(this.mock).createSnapshot(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/AttemptTransitionStepTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/AttemptTransitionStepTests.kt
@@ -1,0 +1,103 @@
+package com.amazon.opendistroforelasticsearch.indexstatemanagement.step
+
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Conditions
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Transition
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.TransitionsActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.transition.AttemptTransitionStep
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
+import org.elasticsearch.action.ActionListener
+import org.elasticsearch.action.admin.indices.stats.CommonStats
+import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse
+import org.elasticsearch.client.AdminClient
+import org.elasticsearch.client.Client
+import org.elasticsearch.client.IndicesAdminClient
+import org.elasticsearch.cluster.ClusterState
+import org.elasticsearch.cluster.metadata.IndexMetadata
+import org.elasticsearch.cluster.metadata.Metadata
+import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.index.shard.DocsStats
+import org.elasticsearch.rest.RestStatus
+import org.elasticsearch.test.ESTestCase
+import org.elasticsearch.transport.RemoteTransportException
+
+class AttemptTransitionStepTests : ESTestCase() {
+
+    private val indexMetadata: IndexMetadata = mock()
+    private val metadata: Metadata = mock { on { index(any<String>()) } doReturn indexMetadata }
+    private val clusterState: ClusterState = mock { on { metadata() } doReturn metadata }
+    private val clusterService: ClusterService = mock { on { state() } doReturn clusterState }
+
+    private val docsStats: DocsStats = mock()
+    private val primaries: CommonStats = mock { on { getDocs() } doReturn docsStats }
+    private val statsResponse: IndicesStatsResponse = mock { on { primaries } doReturn primaries }
+
+    fun `test stats response not OK`() {
+        whenever(indexMetadata.creationDate).doReturn(5L)
+        whenever(statsResponse.status).doReturn(RestStatus.INTERNAL_SERVER_ERROR)
+        whenever(statsResponse.shardFailures).doReturn(IndicesStatsResponse.EMPTY)
+        whenever(docsStats.count).doReturn(6L)
+        whenever(docsStats.totalSizeInBytes).doReturn(2)
+        val client = getClient(getAdminClient(getIndicesAdminClient(statsResponse, null)))
+
+        runBlocking {
+            val config = TransitionsActionConfig(listOf(Transition("some_state", Conditions(docCount = 5L))))
+            val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
+            val step = AttemptTransitionStep(clusterService, client, config, managedIndexMetaData)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get correct failed message", AttemptTransitionStep.getFailedStatsMessage("test"), updatedManagedIndexMetaData.info!!["message"])
+        }
+    }
+
+    fun `test transitions fails on exception`() {
+        whenever(indexMetadata.creationDate).doReturn(5L)
+        val exception = IllegalArgumentException("example")
+        val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
+
+        runBlocking {
+            val config = TransitionsActionConfig(listOf(Transition("some_state", Conditions(docCount = 5L))))
+            val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
+            val step = AttemptTransitionStep(clusterService, client, config, managedIndexMetaData)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get cause from nested exception", "example", updatedManagedIndexMetaData.info!!["cause"])
+        }
+    }
+
+    fun `test transitions remote transport exception`() {
+        whenever(indexMetadata.creationDate).doReturn(5L)
+        val exception = RemoteTransportException("rte", IllegalArgumentException("nested"))
+        val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
+
+        runBlocking {
+            val config = TransitionsActionConfig(listOf(Transition("some_state", Conditions(docCount = 5L))))
+            val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
+            val step = AttemptTransitionStep(clusterService, client, config, managedIndexMetaData)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get cause from nested exception", "nested", updatedManagedIndexMetaData.info!!["cause"])
+        }
+    }
+
+    private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
+    private fun getAdminClient(indicesAdminClient: IndicesAdminClient): AdminClient = mock { on { indices() } doReturn indicesAdminClient }
+    private fun getIndicesAdminClient(statsResponse: IndicesStatsResponse?, exception: Exception?): IndicesAdminClient {
+        assertTrue("Must provide one and only one response or exception", (statsResponse != null).xor(exception != null))
+        return mock {
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<IndicesStatsResponse>>(1)
+                if (statsResponse != null) listener.onResponse(statsResponse)
+                else listener.onFailure(exception)
+            }.whenever(this.mock).stats(any(), any())
+        }
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/AttemptTransitionStepTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/AttemptTransitionStepTests.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.step
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.Conditions

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/SetReadOnlyStepTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/SetReadOnlyStepTests.kt
@@ -16,8 +16,8 @@
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.step
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.IndexPriorityActionConfig
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.indexpriority.AttemptSetIndexPriorityStep
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ReadOnlyActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.readonly.SetReadOnlyStep
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
@@ -32,66 +32,49 @@ import org.elasticsearch.client.IndicesAdminClient
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.test.ESTestCase
 import org.elasticsearch.transport.RemoteTransportException
-import kotlin.IllegalArgumentException
 
-class AttemptSetIndexPriorityStepTests : ESTestCase() {
+class SetReadOnlyStepTests : ESTestCase() {
 
     private val clusterService: ClusterService = mock()
 
-    fun `test set priority step sets step status to completed when successful`() {
-        val acknowledgedResponse = AcknowledgedResponse(true)
-        val client = getClient(getAdminClient(getIndicesAdminClient(acknowledgedResponse, null)))
+    fun `test read only step sets step status to failed when not acknowledged`() {
+        val setReadOnlyResponse = AcknowledgedResponse(false)
+        val client = getClient(getAdminClient(getIndicesAdminClient(setReadOnlyResponse, null)))
 
         runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
+            val readOnlyActionConfig = ReadOnlyActionConfig(0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
-            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
-        }
-    }
-
-    fun `test set priority step sets step status to failed when not acknowledged`() {
-        val acknowledgedResponse = AcknowledgedResponse(false)
-        val client = getClient(getAdminClient(getIndicesAdminClient(acknowledgedResponse, null)))
-
-        runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
-            val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            val setReadOnlyStep = SetReadOnlyStep(clusterService, client, readOnlyActionConfig, managedIndexMetaData)
+            setReadOnlyStep.execute()
+            val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
         }
     }
 
-    fun `test set priority step sets step status to failed when error thrown`() {
+    fun `test read only step sets step status to failed when error thrown`() {
         val exception = IllegalArgumentException("example")
         val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
 
         runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
+            val readOnlyActionConfig = ReadOnlyActionConfig(0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
-            logger.info(updatedManagedIndexMetaData)
+            val setReadOnlyStep = SetReadOnlyStep(clusterService, client, readOnlyActionConfig, managedIndexMetaData)
+            setReadOnlyStep.execute()
+            val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
         }
     }
 
-    fun `test set priority step sets step status to failed when remote transport error thrown`() {
+    fun `test read only step sets step status to failed when remote transport error thrown`() {
         val exception = RemoteTransportException("rte", IllegalArgumentException("nested"))
         val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
 
         runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
+            val readOnlyActionConfig = ReadOnlyActionConfig(0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
-            logger.info(updatedManagedIndexMetaData)
+            val setReadOnlyStep = SetReadOnlyStep(clusterService, client, readOnlyActionConfig, managedIndexMetaData)
+            setReadOnlyStep.execute()
+            val updatedManagedIndexMetaData = setReadOnlyStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
             assertEquals("Did not get cause from nested exception", "nested", updatedManagedIndexMetaData.info!!["cause"])
         }
@@ -99,12 +82,12 @@ class AttemptSetIndexPriorityStepTests : ESTestCase() {
 
     private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
     private fun getAdminClient(indicesAdminClient: IndicesAdminClient): AdminClient = mock { on { indices() } doReturn indicesAdminClient }
-    private fun getIndicesAdminClient(acknowledgedResponse: AcknowledgedResponse?, exception: Exception?): IndicesAdminClient {
-        assertTrue("Must provide one and only one response or exception", (acknowledgedResponse != null).xor(exception != null))
+    private fun getIndicesAdminClient(setReadOnlyResponse: AcknowledgedResponse?, exception: Exception?): IndicesAdminClient {
+        assertTrue("Must provide one and only one response or exception", (setReadOnlyResponse != null).xor(exception != null))
         return mock {
             doAnswer { invocationOnMock ->
                 val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(1)
-                if (acknowledgedResponse != null) listener.onResponse(acknowledgedResponse)
+                if (setReadOnlyResponse != null) listener.onResponse(setReadOnlyResponse)
                 else listener.onFailure(exception)
             }.whenever(this.mock).updateSettings(any(), any())
         }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/SetReadWriteStepTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/SetReadWriteStepTests.kt
@@ -16,8 +16,8 @@
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.step
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.IndexPriorityActionConfig
-import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.indexpriority.AttemptSetIndexPriorityStep
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.ReadWriteActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.readwrite.SetReadWriteStep
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
@@ -32,66 +32,49 @@ import org.elasticsearch.client.IndicesAdminClient
 import org.elasticsearch.cluster.service.ClusterService
 import org.elasticsearch.test.ESTestCase
 import org.elasticsearch.transport.RemoteTransportException
-import kotlin.IllegalArgumentException
 
-class AttemptSetIndexPriorityStepTests : ESTestCase() {
+class SetReadWriteStepTests : ESTestCase() {
 
     private val clusterService: ClusterService = mock()
 
-    fun `test set priority step sets step status to completed when successful`() {
-        val acknowledgedResponse = AcknowledgedResponse(true)
-        val client = getClient(getAdminClient(getIndicesAdminClient(acknowledgedResponse, null)))
+    fun `test read write step sets step status to failed when not acknowledged`() {
+        val setReadWriteResponse = AcknowledgedResponse(false)
+        val client = getClient(getAdminClient(getIndicesAdminClient(setReadWriteResponse, null)))
 
         runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
+            val readWriteActionConfig = ReadWriteActionConfig(0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
-            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
-        }
-    }
-
-    fun `test set priority step sets step status to failed when not acknowledged`() {
-        val acknowledgedResponse = AcknowledgedResponse(false)
-        val client = getClient(getAdminClient(getIndicesAdminClient(acknowledgedResponse, null)))
-
-        runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
-            val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
+            val setReadWriteStep = SetReadWriteStep(clusterService, client, readWriteActionConfig, managedIndexMetaData)
+            setReadWriteStep.execute()
+            val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
         }
     }
 
-    fun `test set priority step sets step status to failed when error thrown`() {
+    fun `test read write step sets step status to failed when error thrown`() {
         val exception = IllegalArgumentException("example")
         val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
 
         runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
+            val readWriteActionConfig = ReadWriteActionConfig(0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
-            logger.info(updatedManagedIndexMetaData)
+            val setReadWriteStep = SetReadWriteStep(clusterService, client, readWriteActionConfig, managedIndexMetaData)
+            setReadWriteStep.execute()
+            val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
         }
     }
 
-    fun `test set priority step sets step status to failed when remote transport error thrown`() {
+    fun `test read write step sets step status to failed when remote transport error thrown`() {
         val exception = RemoteTransportException("rte", IllegalArgumentException("nested"))
         val client = getClient(getAdminClient(getIndicesAdminClient(null, exception)))
 
         runBlocking {
-            val indexPriorityActionConfig = IndexPriorityActionConfig(50, 0)
+            val readWriteActionConfig = ReadWriteActionConfig(0)
             val managedIndexMetaData = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, null, null, null, null)
-            val attemptSetPriorityStep = AttemptSetIndexPriorityStep(clusterService, client, indexPriorityActionConfig, managedIndexMetaData)
-            attemptSetPriorityStep.execute()
-            val updatedManagedIndexMetaData = attemptSetPriorityStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
-            logger.info(updatedManagedIndexMetaData)
+            val setReadWriteStep = SetReadWriteStep(clusterService, client, readWriteActionConfig, managedIndexMetaData)
+            setReadWriteStep.execute()
+            val updatedManagedIndexMetaData = setReadWriteStep.getUpdatedManagedIndexMetaData(managedIndexMetaData)
             assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
             assertEquals("Did not get cause from nested exception", "nested", updatedManagedIndexMetaData.info!!["cause"])
         }
@@ -99,12 +82,12 @@ class AttemptSetIndexPriorityStepTests : ESTestCase() {
 
     private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
     private fun getAdminClient(indicesAdminClient: IndicesAdminClient): AdminClient = mock { on { indices() } doReturn indicesAdminClient }
-    private fun getIndicesAdminClient(acknowledgedResponse: AcknowledgedResponse?, exception: Exception?): IndicesAdminClient {
-        assertTrue("Must provide one and only one response or exception", (acknowledgedResponse != null).xor(exception != null))
+    private fun getIndicesAdminClient(setReadWriteResponse: AcknowledgedResponse?, exception: Exception?): IndicesAdminClient {
+        assertTrue("Must provide one and only one response or exception", (setReadWriteResponse != null).xor(exception != null))
         return mock {
             doAnswer { invocationOnMock ->
                 val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(1)
-                if (acknowledgedResponse != null) listener.onResponse(acknowledgedResponse)
+                if (setReadWriteResponse != null) listener.onResponse(setReadWriteResponse)
                 else listener.onFailure(exception)
             }.whenever(this.mock).updateSettings(any(), any())
         }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/WaitForSnapshotStepTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/WaitForSnapshotStepTests.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.opendistroforelasticsearch.indexstatemanagement.step
 
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/WaitForSnapshotStepTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/step/WaitForSnapshotStepTests.kt
@@ -1,0 +1,178 @@
+package com.amazon.opendistroforelasticsearch.indexstatemanagement.step
+
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.ManagedIndexMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.action.SnapshotActionConfig
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.ActionMetaData
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.model.managedindexmetadata.ActionProperties
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.step.snapshot.WaitForSnapshotStep
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
+import org.elasticsearch.action.ActionListener
+import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotStatus
+import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse
+import org.elasticsearch.client.AdminClient
+import org.elasticsearch.client.Client
+import org.elasticsearch.client.ClusterAdminClient
+import org.elasticsearch.cluster.SnapshotsInProgress
+import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.snapshots.Snapshot
+import org.elasticsearch.snapshots.SnapshotId
+import org.elasticsearch.test.ESTestCase
+import org.elasticsearch.transport.RemoteTransportException
+
+class WaitForSnapshotStepTests : ESTestCase() {
+
+    private val clusterService: ClusterService = mock()
+
+    fun `test snapshot missing snapshot name in action properties`() {
+        val exception = IllegalArgumentException("not used")
+        val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
+        runBlocking {
+            val emptyActionProperties = ActionProperties()
+            val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+            val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, emptyActionProperties), null, null, null)
+            val step = WaitForSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get cause from nested exception", WaitForSnapshotStep.getFailedActionPropertiesMessage("test", emptyActionProperties), updatedManagedIndexMetaData.info!!["message"])
+        }
+
+        runBlocking {
+            val nullActionProperties = null
+            val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+            val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, nullActionProperties), null, null, null)
+            val step = WaitForSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get cause from nested exception", WaitForSnapshotStep.getFailedActionPropertiesMessage("test", nullActionProperties), updatedManagedIndexMetaData.info!!["message"])
+        }
+    }
+
+    fun `test snapshot status states`() {
+        val snapshotStatus: SnapshotStatus = mock()
+        val response: SnapshotsStatusResponse = mock()
+        whenever(response.snapshots).doReturn(listOf(snapshotStatus))
+        whenever(snapshotStatus.snapshot).doReturn(Snapshot("repo", SnapshotId("snapshot-name", "some_uuid")))
+        val client = getClient(getAdminClient(getClusterAdminClient(response, null)))
+
+        whenever(snapshotStatus.state).doReturn(SnapshotsInProgress.State.INIT)
+        runBlocking {
+            val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+            val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
+            val step = WaitForSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get snapshot in progress message", WaitForSnapshotStep.getSnapshotInProgressMessage("test"), updatedManagedIndexMetaData.info!!["message"])
+        }
+
+        whenever(snapshotStatus.state).doReturn(SnapshotsInProgress.State.STARTED)
+        runBlocking {
+            val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+            val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
+            val step = WaitForSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not CONDITION_NOT_MET", Step.StepStatus.CONDITION_NOT_MET, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get snapshot in progress message", WaitForSnapshotStep.getSnapshotInProgressMessage("test"), updatedManagedIndexMetaData.info!!["message"])
+        }
+
+        whenever(snapshotStatus.state).doReturn(SnapshotsInProgress.State.SUCCESS)
+        runBlocking {
+            val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+            val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
+            val step = WaitForSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not COMPLETED", Step.StepStatus.COMPLETED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get snapshot completed message", WaitForSnapshotStep.getSuccessMessage("test"), updatedManagedIndexMetaData.info!!["message"])
+        }
+
+        whenever(snapshotStatus.state).doReturn(SnapshotsInProgress.State.ABORTED)
+        runBlocking {
+            val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+            val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
+            val step = WaitForSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get snapshot failed message", WaitForSnapshotStep.getFailedExistsMessage("test"), updatedManagedIndexMetaData.info!!["message"])
+        }
+
+        whenever(snapshotStatus.state).doReturn(SnapshotsInProgress.State.FAILED)
+        runBlocking {
+            val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+            val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
+            val step = WaitForSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get snapshot failed message", WaitForSnapshotStep.getFailedExistsMessage("test"), updatedManagedIndexMetaData.info!!["message"])
+        }
+    }
+
+    fun `test snapshot not in response list`() {
+        val snapshotStatus: SnapshotStatus = mock()
+        val response: SnapshotsStatusResponse = mock()
+        whenever(response.snapshots).doReturn(listOf(snapshotStatus))
+        whenever(snapshotStatus.snapshot).doReturn(Snapshot("repo", SnapshotId("snapshot-different-name", "some_uuid")))
+        val client = getClient(getAdminClient(getClusterAdminClient(response, null)))
+
+        runBlocking {
+            val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+            val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
+            val step = WaitForSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get snapshot failed message", WaitForSnapshotStep.getFailedExistsMessage("test"), updatedManagedIndexMetaData.info!!["message"])
+        }
+    }
+
+    fun `test snapshot exception`() {
+        val exception = IllegalArgumentException("example")
+        val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
+        runBlocking {
+            val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+            val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
+            val step = WaitForSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get cause from nested exception", "example", updatedManagedIndexMetaData.info!!["cause"])
+        }
+    }
+
+    fun `test snapshot remote transport exception`() {
+        val exception = RemoteTransportException("rte", IllegalArgumentException("nested"))
+        val client = getClient(getAdminClient(getClusterAdminClient(null, exception)))
+        runBlocking {
+            val config = SnapshotActionConfig("repo", "snapshot-name", 0)
+            val metadata = ManagedIndexMetaData("test", "indexUuid", "policy_id", null, null, null, null, null, null, ActionMetaData(WaitForSnapshotStep.name, 1, 0, false, 0, null, ActionProperties(snapshotName = "snapshot-name")), null, null, null)
+            val step = WaitForSnapshotStep(clusterService, client, config, metadata)
+            step.execute()
+            val updatedManagedIndexMetaData = step.getUpdatedManagedIndexMetaData(metadata)
+            assertEquals("Step status is not FAILED", Step.StepStatus.FAILED, updatedManagedIndexMetaData.stepMetaData?.stepStatus)
+            assertEquals("Did not get cause from nested exception", "nested", updatedManagedIndexMetaData.info!!["cause"])
+        }
+    }
+
+    private fun getClient(adminClient: AdminClient): Client = mock { on { admin() } doReturn adminClient }
+    private fun getAdminClient(clusterAdminClient: ClusterAdminClient): AdminClient = mock { on { cluster() } doReturn clusterAdminClient }
+    private fun getClusterAdminClient(snapshotsStatusResponse: SnapshotsStatusResponse?, exception: Exception?): ClusterAdminClient {
+        assertTrue("Must provide one and only one response or exception", (snapshotsStatusResponse != null).xor(exception != null))
+        return mock {
+            doAnswer { invocationOnMock ->
+                val listener = invocationOnMock.getArgument<ActionListener<SnapshotsStatusResponse>>(1)
+                if (snapshotsStatusResponse != null) listener.onResponse(snapshotsStatusResponse)
+                else listener.onFailure(exception)
+            }.whenever(this.mock).snapshotsStatus(any(), any())
+        }
+    }
+}


### PR DESCRIPTION
…saging, adds better try/catch on actions to deal with remote transport exceptions

*Issue #, if available:*
#266, #250

*Description of changes:*
This is a bit of a loaded pull request.
* It changes some of the action message wording to hopefully be a bit more clear. We might change it further to add more information as the "info" object is really supposed to just be a place to dump human friendly/usable information to know what's going on.
* It fixes the force merge bug that would fail if your force merge took too long. This was from the connection not being closed after force merge gets queued/kicked off. We now will hold the connection for up to 5 minutes and then just assume it has succeeded and move on to the wait for step.
* A lot of the action failure messages were useless because of the RemoteTransportException. Correctly catches them in each action and gets the useful error message/cause.
* Added a pre/post execute to steps.
* Fixed some action(s) not correctly catching a snapshot exception that was wrapped in a RemoteTransportException.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
