### PR TITLE
fail rollover on nonwrite index

### DIFF
--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -190,6 +190,16 @@ abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
         return index to policyID
     }
 
+    protected fun rolloverAlias(alias: String) {
+        client()
+        val response = client()
+                .makeRequest(
+                        "POST",
+                        "$alias/_rollover"
+                )
+        assertEquals("Unable to rollover alias", RestStatus.OK, response.restStatus())
+    }
+
     /** Refresh all indices in the cluster */
     protected fun refresh() {
         val request = Request("POST", "/_refresh")


### PR DESCRIPTION
 #261

Per above issue discussion, I'm creating a PR that adds a check during rollover action to see if index being rollovered is actually a write index of an alias.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
