### PR TITLE
Adds support for dynamically updatable synonyms to es version 7.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,7 @@ testClusters.integTest {
 integTest.runner {
     systemProperty 'tests.security.manager', 'false'
     systemProperty 'java.io.tmpdir', es_tmp_dir.absolutePath
+    systemProperty 'buildDir', buildDir
     // Tell the test JVM if the cluster JVM is running under a debugger so that tests can use longer timeouts for
     // requests. The 'doFirst' delays reading the debug setting on the cluster till execution time.
     doFirst {

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementPlugin.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementPlugin.kt
@@ -70,7 +70,8 @@ internal class IndexStateManagementPlugin : JobSchedulerExtension, ActionPlugin,
 
     companion object {
         const val PLUGIN_NAME = "opendistro-ism"
-        const val ISM_BASE_URI = "/_opendistro/_ism"
+        const val OPEN_DISTRO_BASE_URI = "/_opendistro"
+        const val ISM_BASE_URI = "$OPEN_DISTRO_BASE_URI/_ism"
         const val POLICY_BASE_URI = "$ISM_BASE_URI/policies"
         const val INDEX_STATE_MANAGEMENT_INDEX = ".opendistro-ism-config"
         const val INDEX_STATE_MANAGEMENT_JOB_TYPE = "opendistro-managed-index"

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementPlugin.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementPlugin.kt
@@ -28,6 +28,9 @@ import com.amazon.opendistroforelasticsearch.indexstatemanagement.resthandler.Re
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.resthandler.RestRemovePolicyAction
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.resthandler.RestRetryFailedManagedIndexAction
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.settings.ManagedIndexSettings
+import com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer.RefreshSearchAnalyzerAction
+import com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer.RestRefreshSearchAnalyzerAction
+import com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer.TransportRefreshSearchAnalyzerAction
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.JobSchedulerExtension
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobParser
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobRunner
@@ -119,6 +122,7 @@ internal class IndexStateManagementPlugin : JobSchedulerExtension, ActionPlugin,
         nodesInCluster: Supplier<DiscoveryNodes>
     ): List<RestHandler> {
         return listOf(
+            RestRefreshSearchAnalyzerAction(),
             RestIndexPolicyAction(settings, clusterService, indexStateManagementIndices),
             RestGetPolicyAction(),
             RestDeletePolicyAction(),
@@ -186,6 +190,10 @@ internal class IndexStateManagementPlugin : JobSchedulerExtension, ActionPlugin,
             ActionPlugin.ActionHandler(
                 UpdateManagedIndexMetaDataAction.INSTANCE,
                 TransportUpdateManagedIndexMetaDataAction::class.java
+            ),
+            ActionPlugin.ActionHandler(
+                RefreshSearchAnalyzerAction.INSTANCE,
+                TransportRefreshSearchAnalyzerAction::class.java
             )
         )
     }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerAction.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
+
+import org.elasticsearch.action.ActionType
+import org.elasticsearch.common.io.stream.Writeable
+
+class RefreshSearchAnalyzerAction : ActionType<RefreshSearchAnalyzerResponse>(NAME, reader) {
+    companion object {
+        const val NAME = "indices:admin/refresh_search_analyzers"
+        val INSTANCE = RefreshSearchAnalyzerAction()
+        val reader = Writeable.Reader { inp -> RefreshSearchAnalyzerResponse(inp) }
+    }
+
+    override fun getResponseReader(): Writeable.Reader<RefreshSearchAnalyzerResponse> = reader
+}

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerRequest.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerRequest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
+
+import org.elasticsearch.action.support.broadcast.BroadcastRequest
+import org.elasticsearch.common.io.stream.StreamInput
+import java.io.IOException
+
+class RefreshSearchAnalyzerRequest : BroadcastRequest<RefreshSearchAnalyzerRequest> {
+    constructor(vararg indices: String) : super(*indices)
+
+    @Throws(IOException::class)
+    constructor(inp: StreamInput) : super(inp)
+}

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerResponse.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerResponse.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
+
+import org.elasticsearch.action.support.DefaultShardOperationFailedException
+import org.elasticsearch.action.support.broadcast.BroadcastResponse
+import org.elasticsearch.common.io.stream.StreamInput
+import org.elasticsearch.common.io.stream.StreamOutput
+import org.elasticsearch.common.xcontent.ConstructingObjectParser
+import org.elasticsearch.common.xcontent.ToXContent.Params
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.rest.action.RestActions
+import java.io.IOException
+import java.util.function.Function
+
+class RefreshSearchAnalyzerResponse : BroadcastResponse {
+
+    private lateinit var shardResponses: MutableList<RefreshSearchAnalyzerShardResponse>
+    private lateinit var shardFailures: MutableList<DefaultShardOperationFailedException>
+
+    @Throws(IOException::class)
+    constructor(inp: StreamInput) : super(inp) {
+        inp.readList(::RefreshSearchAnalyzerShardResponse)
+        inp.readList(DefaultShardOperationFailedException::readShardOperationFailed)
+    }
+
+    constructor(
+        totalShards: Int,
+        successfulShards: Int,
+        failedShards: Int,
+        shardFailures: List<DefaultShardOperationFailedException>,
+        shardResponses: List<RefreshSearchAnalyzerShardResponse>
+    ) : super(
+            totalShards, successfulShards, failedShards, shardFailures
+    ) {
+        this.shardResponses = shardResponses.toMutableList()
+        this.shardFailures = shardFailures.toMutableList()
+    }
+
+    @Throws(IOException::class)
+    override fun toXContent(builder: XContentBuilder, params: Params?): XContentBuilder? {
+        builder.startObject()
+        RestActions.buildBroadcastShardsHeader(builder, params, totalShards, successfulShards, -1, failedShards, shardFailures.toTypedArray())
+        builder.startArray("successful_refresh_details")
+        val successfulIndices = getSuccessfulRefreshDetails()
+        for (index in successfulIndices.keys) {
+            val reloadedAnalyzers = successfulIndices.get(index)!!
+            builder.startObject().field("index", index).startArray("refreshed_analyzers")
+            for (analyzer in reloadedAnalyzers) {
+                builder.value(analyzer)
+            }
+            builder.endArray().endObject()
+        }
+        builder.endArray().endObject()
+        return builder
+    }
+
+    // TODO: restrict it for testing
+    fun getSuccessfulRefreshDetails(): MutableMap<String, List<String>> {
+        var successfulRefreshDetails: MutableMap<String, List<String>> = HashMap()
+        var failedIndices = mutableSetOf<String>()
+        for (failure in shardFailures) {
+            failedIndices.add(failure.index()!!)
+        }
+        for (response in shardResponses) {
+            if (!failedIndices.contains(response.index)) {
+                successfulRefreshDetails.putIfAbsent(response.index, response.reloadedAnalyzers)
+            }
+        }
+        return successfulRefreshDetails
+    }
+
+    companion object {
+        private val PARSER = ConstructingObjectParser<RefreshSearchAnalyzerResponse, Void>("_refresh_search_analyzers", true,
+                Function { arg: Array<Any> ->
+                    val response = arg[0] as RefreshSearchAnalyzerResponse
+                    RefreshSearchAnalyzerResponse(response.totalShards, response.successfulShards, response.failedShards,
+                            response.shardFailures, response.shardResponses)
+                })
+        init {
+            declareBroadcastFields(PARSER)
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        super.writeTo(out)
+        out.writeCollection(shardResponses)
+        out.writeCollection(shardFailures)
+    }
+}

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerShardResponse.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerShardResponse.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
+
+import org.elasticsearch.action.support.broadcast.BroadcastShardResponse
+import org.elasticsearch.common.io.stream.StreamInput
+import org.elasticsearch.common.io.stream.StreamOutput
+import org.elasticsearch.index.shard.ShardId
+import java.io.IOException
+
+class RefreshSearchAnalyzerShardResponse : BroadcastShardResponse {
+    var reloadedAnalyzers: List<String>
+
+    constructor(si: StreamInput) : super(si) {
+        reloadedAnalyzers = si.readStringArray().toList()
+    }
+
+    constructor(shardId: ShardId, reloadedAnalyzers: List<String>) : super(shardId) {
+        this.reloadedAnalyzers = reloadedAnalyzers
+    }
+
+    @Throws(IOException::class)
+    override fun writeTo(out: StreamOutput) {
+        super.writeTo(out)
+        out.writeStringArray(reloadedAnalyzers.toTypedArray())
+    }
+}

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RestRefreshSearchAnalyzerAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RestRefreshSearchAnalyzerAction.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
 
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateManagementPlugin.Companion.OPEN_DISTRO_BASE_URI
 import org.elasticsearch.client.node.NodeClient
 import org.elasticsearch.common.Strings
 import org.elasticsearch.rest.BaseRestHandler
@@ -55,7 +56,6 @@ class RestRefreshSearchAnalyzerAction : BaseRestHandler() {
     }
 
     companion object {
-        const val OPEN_DISTRO_BASE_URI = "/_opendistro"
         const val REFRESH_SEARCH_ANALYZER_BASE_URI = "$OPEN_DISTRO_BASE_URI/_refresh_search_analyzers"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RestRefreshSearchAnalyzerAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RestRefreshSearchAnalyzerAction.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
+
+import org.elasticsearch.client.node.NodeClient
+import org.elasticsearch.common.Strings
+import org.elasticsearch.rest.BaseRestHandler
+import org.elasticsearch.rest.RestHandler.Route
+import org.elasticsearch.rest.RestRequest
+import org.elasticsearch.rest.RestRequest.Method.POST
+import org.elasticsearch.rest.action.RestToXContentListener
+import java.io.IOException
+
+class RestRefreshSearchAnalyzerAction : BaseRestHandler() {
+
+    override fun getName(): String = "refresh_search_analyzer_action"
+
+    override fun routes(): List<Route> {
+        return listOf(
+                Route(POST, REFRESH_SEARCH_ANALYZER_BASE_URI),
+                Route(POST, "$REFRESH_SEARCH_ANALYZER_BASE_URI/{index}")
+        )
+    }
+
+    // TODO: Add indicesOptions?
+
+    @Throws(IOException::class)
+    @Suppress("SpreadOperator")
+    override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
+        val indices: Array<String>? = Strings.splitStringByCommaToArray(request.param("index"))
+
+        if (indices.isNullOrEmpty()) {
+            throw IllegalArgumentException("Missing indices")
+        }
+
+        val refreshSearchAnalyzerRequest: RefreshSearchAnalyzerRequest = RefreshSearchAnalyzerRequest()
+                .indices(*indices)
+
+        return RestChannelConsumer { channel ->
+            client.execute(RefreshSearchAnalyzerAction.INSTANCE, refreshSearchAnalyzerRequest, RestToXContentListener(channel))
+        }
+    }
+
+    companion object {
+        const val OPEN_DISTRO_BASE_URI = "/_opendistro"
+        const val REFRESH_SEARCH_ANALYZER_BASE_URI = "$OPEN_DISTRO_BASE_URI/_refresh_search_analyzers"
+    }
+}

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/TransportRefreshSearchAnalyzerAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/TransportRefreshSearchAnalyzerAction.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
+
+import org.apache.logging.log4j.LogManager
+import org.elasticsearch.action.support.ActionFilters
+import org.elasticsearch.action.support.DefaultShardOperationFailedException
+import org.elasticsearch.action.support.broadcast.node.TransportBroadcastByNodeAction
+import org.elasticsearch.cluster.ClusterState
+import org.elasticsearch.cluster.block.ClusterBlockException
+import org.elasticsearch.cluster.block.ClusterBlockLevel
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver
+import org.elasticsearch.cluster.routing.ShardRouting
+import org.elasticsearch.cluster.routing.ShardsIterator
+import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.common.inject.Inject
+import org.elasticsearch.common.io.stream.StreamInput
+import org.elasticsearch.common.io.stream.Writeable
+import org.elasticsearch.index.analysis.AnalysisRegistry
+import org.elasticsearch.index.shard.IndexShard
+import org.elasticsearch.indices.IndicesService
+import org.elasticsearch.threadpool.ThreadPool
+import org.elasticsearch.transport.TransportService
+import java.io.IOException
+
+class TransportRefreshSearchAnalyzerAction :
+        TransportBroadcastByNodeAction<
+                RefreshSearchAnalyzerRequest,
+                RefreshSearchAnalyzerResponse,
+                RefreshSearchAnalyzerShardResponse> {
+
+    private val log = LogManager.getLogger(javaClass)
+
+    @Inject
+    constructor(
+        clusterService: ClusterService,
+        transportService: TransportService,
+        indicesService: IndicesService,
+        actionFilters: ActionFilters,
+        analysisRegistry: AnalysisRegistry,
+        indexNameExpressionResolver: IndexNameExpressionResolver?
+    ) : super(
+            RefreshSearchAnalyzerAction.NAME,
+            clusterService,
+            transportService,
+            actionFilters,
+            indexNameExpressionResolver,
+            Writeable.Reader { RefreshSearchAnalyzerRequest() },
+            ThreadPool.Names.MANAGEMENT
+    ) {
+        this.analysisRegistry = analysisRegistry
+        this.indicesService = indicesService
+    }
+
+    private val indicesService: IndicesService
+    private val analysisRegistry: AnalysisRegistry
+
+    @Throws(IOException::class)
+    override fun readShardResult(si: StreamInput): RefreshSearchAnalyzerShardResponse? {
+        return RefreshSearchAnalyzerShardResponse(si)
+    }
+
+    override fun newResponse(
+        request: RefreshSearchAnalyzerRequest,
+        totalShards: Int,
+        successfulShards: Int,
+        failedShards: Int,
+        shardResponses: List<RefreshSearchAnalyzerShardResponse>,
+        shardFailures: List<DefaultShardOperationFailedException>,
+        clusterState: ClusterState
+    ): RefreshSearchAnalyzerResponse {
+        return RefreshSearchAnalyzerResponse(totalShards, successfulShards, failedShards, shardFailures, shardResponses)
+    }
+
+    @Throws(IOException::class)
+    override fun readRequestFrom(si: StreamInput): RefreshSearchAnalyzerRequest {
+        return RefreshSearchAnalyzerRequest(si)
+    }
+
+    @Throws(IOException::class)
+    override fun shardOperation(request: RefreshSearchAnalyzerRequest, shardRouting: ShardRouting): RefreshSearchAnalyzerShardResponse {
+        val indexShard: IndexShard = indicesService.indexServiceSafe(shardRouting.shardId().index).getShard(shardRouting.shardId().id())
+        val reloadedAnalyzers: List<String> = indexShard.mapperService().reloadSearchAnalyzers(analysisRegistry)
+        log.info("Reload successful, index: ${shardRouting.shardId().index.name}, shard: ${shardRouting.shardId().id}, " +
+                "is_primary: ${shardRouting.primary()}")
+        return RefreshSearchAnalyzerShardResponse(shardRouting.shardId(), reloadedAnalyzers)
+    }
+
+    /**
+     * The refresh request works against *all* shards.
+     */
+    override fun shards(clusterState: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?): ShardsIterator? {
+        return clusterState.routingTable().allShards(concreteIndices)
+    }
+
+    override fun checkGlobalBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?): ClusterBlockException? {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE)
+    }
+
+    override fun checkRequestBlock(state: ClusterState, request: RefreshSearchAnalyzerRequest?, concreteIndices: Array<String?>?):
+            ClusterBlockException? {
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE, concreteIndices)
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/IndexManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/IndexManagementRestTestCase.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement
+
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.makeRequest
+import org.elasticsearch.client.Response
+import org.elasticsearch.rest.RestStatus
+import org.elasticsearch.test.rest.ESRestTestCase
+
+abstract class IndexManagementRestTestCase : ESRestTestCase() {
+
+    fun Response.asMap(): Map<String, Any> = entityAsMap(this)
+
+    protected fun Response.restStatus(): RestStatus = RestStatus.fromCode(this.statusLine.statusCode)
+
+    @Suppress("UNCHECKED_CAST")
+    protected fun getRepoPath(): String {
+        val response = client()
+                .makeRequest(
+                        "GET",
+                        "_nodes",
+                        emptyMap()
+                )
+        assertEquals("Unable to get a nodes settings", RestStatus.OK, response.restStatus())
+        return ((response.asMap()["nodes"] as HashMap<String, HashMap<String, HashMap<String, HashMap<String, Any>>>>).values.first()["settings"]!!["path"]!!["repo"] as List<String>)[0]
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.indexstatemanagement
 
+import com.amazon.opendistroforelasticsearch.indexmanagement.IndexManagementRestTestCase
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateManagementPlugin.Companion.INDEX_STATE_MANAGEMENT_HISTORY_TYPE
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateManagementPlugin.Companion.INDEX_STATE_MANAGEMENT_INDEX
 import com.amazon.opendistroforelasticsearch.indexstatemanagement.IndexStateManagementPlugin.Companion.POLICY_BASE_URI
@@ -61,7 +62,6 @@ import org.elasticsearch.index.seqno.SequenceNumbers
 import org.elasticsearch.rest.RestRequest
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.test.ESTestCase
-import org.elasticsearch.test.rest.ESRestTestCase
 import org.junit.AfterClass
 import org.junit.rules.DisableOnDebug
 import java.io.IOException
@@ -75,12 +75,10 @@ import javax.management.ObjectName
 import javax.management.remote.JMXConnectorFactory
 import javax.management.remote.JMXServiceURL
 
-abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
+abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() {
 
     private val isDebuggingTest = DisableOnDebug(null).isDebugging
     private val isDebuggingRemoteCluster = System.getProperty("cluster.debug", "false")!!.toBoolean()
-
-    fun Response.asMap(): Map<String, Any> = entityAsMap(this)
 
     protected fun createPolicy(
         policy: Policy,
@@ -312,8 +310,6 @@ abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
         assertEquals("Request failed", RestStatus.OK, response.restStatus())
     }
 
-    protected fun Response.restStatus(): RestStatus = RestStatus.fromCode(this.statusLine.statusCode)
-
     protected fun Policy.toHttpEntity(): HttpEntity = StringEntity(toJsonString(), APPLICATION_JSON)
 
     protected fun ManagedIndexConfig.toHttpEntity(): HttpEntity = StringEntity(toJsonString(), APPLICATION_JSON)
@@ -444,18 +440,6 @@ abstract class IndexStateManagementRestTestCase : ESRestTestCase() {
                 StringEntity("{\"type\":\"fs\", \"settings\": {\"location\": \"$path\"}}", APPLICATION_JSON)
             )
         assertEquals("Unable to create a new repository", RestStatus.OK, response.restStatus())
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun getRepoPath(): String {
-        val response = client()
-            .makeRequest(
-                "GET",
-                "_nodes",
-                emptyMap()
-            )
-        assertEquals("Unable to get a nodes settings", RestStatus.OK, response.restStatus())
-        return ((response.asMap()["nodes"] as HashMap<String, HashMap<String, HashMap<String, HashMap<String, Any>>>>).values.first()["settings"]!!["path"]!!["repo"] as List<String>)[0]
     }
 
     private fun getSnapshotsList(repository: String): List<Any> {

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerActionIT.kt
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
+
+import com.amazon.opendistroforelasticsearch.indexmanagement.IndexManagementRestTestCase
+import com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer.RestRefreshSearchAnalyzerAction.Companion.REFRESH_SEARCH_ANALYZER_BASE_URI
+import org.elasticsearch.client.Request
+import org.elasticsearch.common.io.Streams
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.xcontent.XContentType
+import java.io.InputStreamReader
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+class RefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
+    fun `test index time analyzer`() {
+        val buildDir = System.getProperty("buildDir")
+        val numNodes = System.getProperty("cluster.number_of_nodes", "1").toInt()
+        val indexName = "testindex"
+
+        for (i in 0 until numNodes) {
+            writeToFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt", "hello, hola")
+        }
+
+        val settings: Settings = Settings.builder()
+                .loadFromSource(getIndexAnalyzerSettings(), XContentType.JSON)
+                .build()
+        createIndex(indexName, settings, getAnalyzerMapping())
+        ingestData(indexName)
+
+        assertTrue(queryData(indexName, "hello").contains("hello world"))
+
+        // check synonym
+        val result2 = queryData(indexName, "hola")
+        assertTrue(result2.contains("hello world"))
+
+        // check non synonym
+        val result3 = queryData(indexName, "namaste")
+        assertFalse(result3.contains("hello world"))
+
+        for (i in 0 until numNodes) {
+            writeToFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt", "hello, hola, namaste")
+        }
+
+        // New added synonym should NOT match
+        val result4 = queryData(indexName, "namaste")
+        assertFalse(result4.contains("hello world"))
+
+        // refresh synonyms
+        refreshAnalyzer(indexName)
+
+        // New added synonym should NOT match
+        val result5 = queryData(indexName, "namaste")
+        assertFalse(result5.contains("hello world"))
+
+        // clean up
+        for (i in 0 until numNodes) {
+            deleteFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt")
+        }
+    }
+
+    fun `test search time analyzer`() {
+        val buildDir = System.getProperty("buildDir")
+        val numNodes = System.getProperty("cluster.number_of_nodes", "1").toInt()
+        val indexName = "testindex"
+
+        for (i in 0 until numNodes) {
+            writeToFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt", "hello, hola")
+        }
+
+        val settings: Settings = Settings.builder()
+                .loadFromSource(getSearchAnalyzerSettings(), XContentType.JSON)
+                .build()
+        createIndex(indexName, settings, getAnalyzerMapping())
+        ingestData(indexName)
+
+        assertTrue(queryData(indexName, "hello").contains("hello world"))
+
+        // check synonym
+        val result2 = queryData(indexName, "hola")
+        assertTrue(result2.contains("hello world"))
+
+        // check non synonym
+        val result3 = queryData(indexName, "namaste")
+        assertFalse(result3.contains("hello world"))
+
+        for (i in 0 until numNodes) {
+            writeToFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt", "hello, hola, namaste")
+        }
+
+        // New added synonym should NOT match
+        val result4 = queryData(indexName, "namaste")
+        assertFalse(result4.contains("hello world"))
+
+        // refresh synonyms
+        refreshAnalyzer(indexName)
+
+        // New added synonym should match
+        val result5 = queryData(indexName, "namaste")
+        assertTrue(result5.contains("hello world"))
+
+        // clean up
+        for (i in 0 until numNodes) {
+            deleteFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt")
+        }
+    }
+
+    fun `test alias`() {
+        val indexName = "testindex"
+        val numNodes = System.getProperty("cluster.number_of_nodes", "1").toInt()
+        val buildDir = System.getProperty("buildDir")
+        val aliasName = "test"
+        val aliasSettings = "\"$aliasName\": {}"
+
+        for (i in 0 until numNodes) {
+            writeToFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt", "hello, hola")
+        }
+
+        val settings: Settings = Settings.builder()
+                .loadFromSource(getSearchAnalyzerSettings(), XContentType.JSON)
+                .build()
+        createIndex(indexName, settings, getAnalyzerMapping(), aliasSettings)
+        ingestData(indexName)
+
+        assertTrue(queryData(indexName, "hello").contains("hello world"))
+
+        // check synonym
+        val result2 = queryData(aliasName, "hola")
+        assertTrue(result2.contains("hello world"))
+
+        // check non synonym
+        val result3 = queryData(aliasName, "namaste")
+        assertFalse(result3.contains("hello world"))
+
+        for (i in 0 until numNodes) {
+            writeToFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt", "hello, hola, namaste")
+        }
+
+        // New added synonym should NOT match
+        val result4 = queryData(aliasName, "namaste")
+        assertFalse(result4.contains("hello world"))
+
+        // refresh synonyms
+        refreshAnalyzer(aliasName)
+
+        // New added synonym should match
+        val result5 = queryData(aliasName, "namaste")
+        assertTrue(result5.contains("hello world"))
+
+        for (i in 0 until numNodes) {
+            deleteFile("$buildDir/testclusters/integTest-$i/config/pacman_synonyms.txt")
+        }
+    }
+
+    companion object {
+
+        fun writeToFile(filePath: String, contents: String) {
+            var path = org.elasticsearch.common.io.PathUtils.get(filePath)
+            Files.newBufferedWriter(path, Charset.forName("UTF-8")).use { writer -> writer.write(contents) }
+        }
+
+        fun deleteFile(filePath: String) {
+            Files.deleteIfExists(org.elasticsearch.common.io.PathUtils.get(filePath))
+        }
+
+        fun ingestData(indexName: String) {
+            val request = Request("POST", "/$indexName/_doc?refresh=true")
+            val data: String = """
+                {
+                  "title": "hello world..."
+                }
+            """.trimIndent()
+            request.setJsonEntity(data)
+            client().performRequest(request)
+        }
+
+        fun queryData(indexName: String, query: String): String {
+            val request = Request("GET", "/$indexName/_search?q=$query")
+            val response = client().performRequest(request)
+            return Streams.copyToString(InputStreamReader(response.entity.content, StandardCharsets.UTF_8))
+        }
+
+        fun refreshAnalyzer(indexName: String) {
+            val request = Request("POST",
+                    "$REFRESH_SEARCH_ANALYZER_BASE_URI/$indexName")
+            client().performRequest(request)
+        }
+
+        fun getSearchAnalyzerSettings(): String {
+            return """
+            {
+                "index" : {
+                    "analysis" : {
+                        "analyzer" : {
+                            "my_synonyms" : {
+                                "tokenizer" : "whitespace",
+                                "filter" : ["synonym"]
+                            }
+                        },
+                        "filter" : {
+                            "synonym" : {
+                                "type" : "synonym_graph",
+                                "synonyms_path" : "pacman_synonyms.txt", 
+                                "updateable" : true 
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+        }
+
+        fun getIndexAnalyzerSettings(): String {
+            return """
+            {
+                "index" : {
+                    "analysis" : {
+                        "analyzer" : {
+                            "my_synonyms" : {
+                                "tokenizer" : "whitespace",
+                                "filter" : ["synonym"]
+                            }
+                        },
+                        "filter" : {
+                            "synonym" : {
+                                "type" : "synonym_graph",
+                                "synonyms_path" : "pacman_synonyms.txt"
+                            }
+                        }
+                    }
+                }
+            }
+            """.trimIndent()
+        }
+
+        fun getAnalyzerMapping(): String {
+            return """
+            "properties": {
+                    "title": {
+                        "type": "text",
+                        "analyzer" : "standard",
+                        "search_analyzer": "my_synonyms"
+                    }
+                }
+            """.trimIndent()
+        }
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerResponseTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerResponseTests.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
+
+import org.elasticsearch.action.support.DefaultShardOperationFailedException
+import org.elasticsearch.index.shard.ShardId
+import org.elasticsearch.test.ESTestCase
+import org.junit.Assert
+
+class RefreshSearchAnalyzerResponseTests : ESTestCase() {
+
+    fun `test get successful refresh details`() {
+        val index1 = "index1"
+        val index2 = "index2"
+        val syn1 = "synonym1"
+        val syn2 = "synonym2"
+        val i1s0 = ShardId(index1, "abc", 0)
+        val i1s1 = ShardId(index1, "abc", 1)
+        val i2s0 = ShardId(index2, "xyz", 0)
+        val i2s1 = ShardId(index2, "xyz", 1)
+
+        var response_i1s0 = RefreshSearchAnalyzerShardResponse(i1s0, listOf(syn1, syn2))
+        var response_i1s1 = RefreshSearchAnalyzerShardResponse(i1s1, listOf(syn1, syn2))
+        var response_i2s0 = RefreshSearchAnalyzerShardResponse(i2s0, listOf(syn1))
+        var response_i2s1 = RefreshSearchAnalyzerShardResponse(i2s1, listOf(syn1))
+        var failure_i1s0 = DefaultShardOperationFailedException(index1, 0, Throwable("dummyCause"))
+        var failure_i1s1 = DefaultShardOperationFailedException(index1, 1, Throwable("dummyCause"))
+        var failure_i2s0 = DefaultShardOperationFailedException(index2, 0, Throwable("dummyCause"))
+        var failure_i2s1 = DefaultShardOperationFailedException(index2, 1, Throwable("dummyCause"))
+
+        // Case 1: All shards successful
+        var aggregate_response = listOf(response_i1s0, response_i1s1, response_i2s0, response_i2s1)
+        var aggregate_failures = listOf<DefaultShardOperationFailedException>()
+        var refreshSearchAnalyzerResponse = RefreshSearchAnalyzerResponse(4, 4, 0, aggregate_failures, aggregate_response)
+        var successfulIndices = refreshSearchAnalyzerResponse.getSuccessfulRefreshDetails()
+        Assert.assertTrue(successfulIndices.containsKey(index1))
+        Assert.assertTrue(successfulIndices.containsKey(index2))
+
+        // Case 2: All shards failed
+        aggregate_response = listOf<RefreshSearchAnalyzerShardResponse>()
+        aggregate_failures = listOf(failure_i1s0, failure_i1s1, failure_i2s0, failure_i2s1)
+        refreshSearchAnalyzerResponse = RefreshSearchAnalyzerResponse(4, 0, 4, aggregate_failures, aggregate_response)
+        successfulIndices = refreshSearchAnalyzerResponse.getSuccessfulRefreshDetails()
+        Assert.assertTrue(successfulIndices.isEmpty())
+
+        // Case 3: Some shards of an index fail, while some others succeed
+        aggregate_response = listOf(response_i1s1, response_i2s0, response_i2s1)
+        aggregate_failures = listOf(failure_i1s0)
+        refreshSearchAnalyzerResponse = RefreshSearchAnalyzerResponse(4, 3, 1, aggregate_failures, aggregate_response)
+        successfulIndices = refreshSearchAnalyzerResponse.getSuccessfulRefreshDetails()
+        Assert.assertTrue(successfulIndices.containsKey(index2))
+        Assert.assertFalse(successfulIndices.containsKey(index1))
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerShardResponseTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RefreshSearchAnalyzerShardResponseTests.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
+
+import org.elasticsearch.common.io.stream.BytesStreamOutput
+import org.elasticsearch.index.Index
+import org.elasticsearch.index.shard.ShardId
+import org.elasticsearch.test.ESTestCase
+import org.junit.Assert
+
+class RefreshSearchAnalyzerShardResponseTests : ESTestCase() {
+
+    fun `test shard refresh response parsing`() {
+        val reloadedAnalyzers = listOf("analyzer1", "analyzer2")
+        val refreshShardResponse = RefreshSearchAnalyzerShardResponse(ShardId(Index("testIndex", "qwerty"), 0), reloadedAnalyzers)
+
+        val refreshShardResponse2 = roundTripRequest(refreshShardResponse)
+        Assert.assertEquals(refreshShardResponse2.shardId, refreshShardResponse.shardId)
+    }
+
+    @Throws(Exception::class)
+    private fun roundTripRequest(response: RefreshSearchAnalyzerShardResponse): RefreshSearchAnalyzerShardResponse {
+        BytesStreamOutput().use { out ->
+            response.writeTo(out)
+            out.bytes().streamInput().use { si -> return RefreshSearchAnalyzerShardResponse(si) }
+        }
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RestRefreshSearchAnalyzerActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/refreshanalyzer/RestRefreshSearchAnalyzerActionIT.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer
+
+import com.amazon.opendistroforelasticsearch.indexmanagement.IndexManagementRestTestCase
+import com.amazon.opendistroforelasticsearch.indexstatemanagement.makeRequest
+import com.amazon.opendistroforelasticsearch.indexmanagement.refreshanalyzer.RestRefreshSearchAnalyzerAction.Companion.REFRESH_SEARCH_ANALYZER_BASE_URI
+import org.elasticsearch.client.ResponseException
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.rest.RestRequest.Method.POST
+import org.elasticsearch.rest.RestStatus
+
+class RestRefreshSearchAnalyzerActionIT : IndexManagementRestTestCase() {
+
+    fun `test missing indices`() {
+        try {
+            client().makeRequest(POST.toString(), REFRESH_SEARCH_ANALYZER_BASE_URI)
+            fail("Expected a failure")
+        } catch (e: ResponseException) {
+            assertEquals("Unexpected RestStatus", RestStatus.BAD_REQUEST, e.response.restStatus())
+            val actualMessage = e.response.asMap()
+            val expectedErrorMessage = mapOf(
+                    "error" to mapOf(
+                            "root_cause" to listOf<Map<String, Any>>(
+                                    mapOf("type" to "illegal_argument_exception", "reason" to "Missing indices")
+                            ),
+                            "type" to "illegal_argument_exception",
+                            "reason" to "Missing indices"
+                    ),
+                    "status" to 400
+            )
+            assertEquals(expectedErrorMessage, actualMessage)
+        }
+    }
+
+    fun `test closed index`() {
+        val indexName = "testindex"
+        val settings = Settings.builder().build()
+        createIndex(indexName, settings)
+        closeIndex(indexName)
+
+        try {
+            client().makeRequest(POST.toString(), "$REFRESH_SEARCH_ANALYZER_BASE_URI/$indexName")
+            fail("Expected a failure")
+        } catch (e: ResponseException) {
+            val response = e.response.asMap()
+            assertEquals(400, response.get("status"))
+            assertEquals("index_closed_exception", (response.get("error") as HashMap<*, *>).get("type"))
+        }
+    }
+}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This change is to add support for hot update of search analyzers in Elasticsearch. It exposes a new REST Api `POST /_opendistro/_refresh_search_analyzers/{index}`, which when invoked, refreshes those analyzers in memory which were created with is_updateable flag as true. This can be used to refresh synonym list used for search time analysis, without closing and reopening the index.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
