### PR TITLE
Change integration tests to use relative paths for snapshot repositories

### DIFF
--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -499,13 +499,12 @@ abstract class IndexStateManagementRestTestCase : IndexManagementRestTestCase() 
     protected fun createRepository(
         repository: String
     ) {
-        val path = getRepoPath()
         val response = client()
             .makeRequest(
                 "PUT",
                 "_snapshot/$repository",
                 emptyMap(),
-                StringEntity("{\"type\":\"fs\", \"settings\": {\"location\": \"$path\"}}", APPLICATION_JSON)
+                StringEntity("{\"type\":\"fs\", \"settings\": {\"location\": \"$repository\"}}", APPLICATION_JSON)
             )
         assertEquals("Unable to create a new repository", RestStatus.OK, response.restStatus())
     }


### PR DESCRIPTION
*Description of changes:*
Change the integration tests to use relative paths for snapshot repositories. This breaks the dependency on having the path match the value in `path.repo`.

*Testing done:*
`gradlew integTest` succeeded

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
