### PR TITLE
Explicitly sets replicas and shards to 1 for ISM history indices

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/IndexManagementIndices.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/IndexManagementIndices.kt
@@ -118,7 +118,8 @@ class IndexManagementIndices(
 
         val request = CreateIndexRequest(index)
                 .mapping(_DOC, indexStateManagementHistoryMappings, XContentType.JSON)
-                .settings(Settings.builder().put("index.hidden", true).build())
+                .settings(Settings.builder().put("index.hidden", true)
+                    .put("index.number_of_shards", 1).put("index.number_of_replicas", 1).build())
         if (alias != null) request.alias(Alias(alias))
         return try {
             val createIndexResponse: CreateIndexResponse = client.suspendUntil { client.create(request, it) }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementHistory.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementHistory.kt
@@ -120,8 +120,8 @@ class IndexStateManagementHistory(
         // We have to pass null for newIndexName in order to get Elastic to increment the index count.
         val request = RolloverRequest(IndexManagementIndices.HISTORY_WRITE_INDEX_ALIAS, null)
         request.createIndexRequest.index(IndexManagementIndices.HISTORY_INDEX_PATTERN)
-            .mapping(_DOC,
-                IndexManagementIndices.indexStateManagementHistoryMappings, XContentType.JSON)
+            .mapping(_DOC, IndexManagementIndices.indexStateManagementHistoryMappings, XContentType.JSON)
+            .settings(Settings.builder().put("index.hidden", true).put("index.number_of_shards", 1).put("index.number_of_replicas", 1))
         request.addMaxIndexDocsCondition(historyMaxDocs)
         request.addMaxIndexAgeCondition(historyMaxAge)
         val response = client.admin().indices().rolloverIndex(request).actionGet()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Explicitly sets replicas and shards to 1 for ISM history indices

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
