### PR TITLE
Fixes start API not setting FAILED metadata to RETRY. Also fixes bug …

### DIFF
--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/resthandler/RestStartRollupActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/resthandler/RestStartRollupActionIT.kt
@@ -18,10 +18,17 @@ package com.amazon.opendistroforelasticsearch.indexmanagement.rollup.resthandler
 import com.amazon.opendistroforelasticsearch.indexmanagement.IndexManagementPlugin.Companion.ROLLUP_JOBS_BASE_URI
 import com.amazon.opendistroforelasticsearch.indexmanagement.makeRequest
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.RollupRestTestCase
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.Rollup
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.RollupMetadata
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.dimension.DateHistogram
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.randomRollup
+import com.amazon.opendistroforelasticsearch.indexmanagement.waitFor
+import com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule.IntervalSchedule
 import org.elasticsearch.client.ResponseException
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.test.junit.annotations.TestLogging
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 @TestLogging(value = "level:DEBUG", reason = "Debugging tests")
 @Suppress("UNCHECKED_CAST")
@@ -75,6 +82,124 @@ class RestStartRollupActionIT : RollupRestTestCase() {
             fail("Expected 400 Method BAD_REQUEST response")
         } catch (e: ResponseException) {
             assertEquals("Unexpected status", RestStatus.BAD_REQUEST, e.response.restStatus())
+        }
+    }
+
+    @Throws(Exception::class)
+    fun `test starting a failed rollup`() {
+        val rollup = Rollup(
+            id = "restart_failed_rollup",
+            schemaVersion = 1L,
+            enabled = true,
+            jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
+            jobLastUpdatedTime = Instant.now(),
+            jobEnabledTime = Instant.now(),
+            description = "basic search test",
+            sourceIndex = "source_restart_failed_rollup",
+            targetIndex = "target_restart_failed_rollup",
+            metadataID = null,
+            roles = emptyList(),
+            pageSize = 10,
+            delay = 0,
+            continuous = false,
+            dimensions = listOf(DateHistogram(sourceField = "tpep_pickup_datetime", fixedInterval = "1h")),
+            metrics = emptyList()
+        ).let { createRollup(it, it.id) }
+
+        // This should fail because we did not create a source index
+        updateRollupStartTime(rollup)
+
+        waitFor {
+            val updatedRollup = getRollup(rollupId = rollup.id)
+            assertNotNull("MetadataID on rollup was null", updatedRollup.metadataID)
+            val metadata = getRollupMetadata(updatedRollup.metadataID!!)
+            // It should be failed because we did not create the source index
+            assertEquals("Status should be failed", RollupMetadata.Status.FAILED, metadata.status)
+            assertFalse("Rollup was not disabled", updatedRollup.enabled)
+        }
+
+        // Now create the missing source index
+        generateNYCTaxiData("source_restart_failed_rollup")
+
+        // And call _start on the failed rollup job
+        val response = client().makeRequest("POST", "$ROLLUP_JOBS_BASE_URI/${rollup.id}/_start")
+        assertEquals("Start rollup failed", RestStatus.OK, response.restStatus())
+        val expectedResponse = mapOf("acknowledged" to true)
+        assertEquals(expectedResponse, response.asMap())
+
+        val updatedRollup = getRollup(rollup.id)
+        assertTrue("Rollup was not enabled", updatedRollup.enabled)
+        waitFor {
+            val metadata = getRollupMetadata(updatedRollup.metadataID!!)
+            // It should be in retry now
+            assertEquals("Status should be retry", RollupMetadata.Status.RETRY, metadata.status)
+        }
+
+        updateRollupStartTime(rollup)
+
+        // Rollup should be able to finished, with actual rolled up docs
+        waitFor {
+            val metadata = getRollupMetadata(updatedRollup.metadataID!!)
+            assertEquals("Status should be finished", RollupMetadata.Status.FINISHED, metadata.status)
+            assertEquals("Did not roll up documents", 5000, metadata.stats.documentsProcessed)
+            assertTrue("Did not roll up documents", metadata.stats.rollupsIndexed > 0)
+        }
+    }
+
+    @Throws(Exception::class)
+    fun `test starting a finished rollup`() {
+        generateNYCTaxiData("source_restart_finished_rollup")
+        val rollup = Rollup(
+            id = "restart_finished_rollup",
+            schemaVersion = 1L,
+            enabled = true,
+            jobSchedule = IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES),
+            jobLastUpdatedTime = Instant.now(),
+            jobEnabledTime = Instant.now(),
+            description = "basic search test",
+            sourceIndex = "source_restart_finished_rollup",
+            targetIndex = "target_restart_finished_rollup",
+            metadataID = null,
+            roles = emptyList(),
+            pageSize = 10,
+            delay = 0,
+            continuous = false,
+            dimensions = listOf(DateHistogram(sourceField = "tpep_pickup_datetime", fixedInterval = "1h")),
+            metrics = emptyList()
+        ).let { createRollup(it, it.id) }
+
+        updateRollupStartTime(rollup)
+        var firstRollupsIndexed = 0L
+        waitFor {
+            val updatedRollup = getRollup(rollupId = rollup.id)
+            val metadata = getRollupMetadata(updatedRollup.metadataID!!)
+            assertEquals("Status should be finished", RollupMetadata.Status.FINISHED, metadata.status)
+            assertEquals("Did not roll up documents", 5000, metadata.stats.documentsProcessed)
+            assertTrue("Did not roll up documents", metadata.stats.rollupsIndexed > 0)
+            firstRollupsIndexed = metadata.stats.rollupsIndexed
+        }
+
+        deleteIndex("target_restart_finished_rollup")
+
+        // And call _start on the failed rollup job
+        val response = client().makeRequest("POST", "$ROLLUP_JOBS_BASE_URI/${rollup.id}/_start")
+        assertEquals("Start rollup failed", RestStatus.OK, response.restStatus())
+        val expectedResponse = mapOf("acknowledged" to true)
+        assertEquals(expectedResponse, response.asMap())
+
+        updateRollupStartTime(rollup)
+
+        // Rollup should be able to finished, with actual rolled up docs again
+        waitFor {
+            val updatedRollup = getRollup(rollupId = rollup.id)
+            val metadata = getRollupMetadata(updatedRollup.metadataID!!)
+            // logger.info("metadata $metadata")
+            assertEquals("Status should be finished", RollupMetadata.Status.FINISHED, metadata.status)
+            // Expect 10k docs now (5k from first and 5k from second)
+            assertEquals("Did not roll up documents", 10000, metadata.stats.documentsProcessed)
+            // Should have twice the rollups indexed now
+            assertEquals("Did not index rollup docs", firstRollupsIndexed * 2, metadata.stats.rollupsIndexed)
+            assertIndexExists("target_restart_finished_rollup")
         }
     }
 }


### PR DESCRIPTION
…with releaseLock not correclty releasing an updated lock

*Issue #, if available:*

*Description of changes:*
Previously Start API was setting everything to STARTED no matter what, now it will:
Skip updating any metadata that is already in: [STARTED, INIT, RETRY]
Set these to STARTED: [FINISHED, STOPPED]
And set FAILED to RETRY

There was also a bug with runRollupJob where we constantly renewed the lock which is updating the seqNo/primaryTerm. So once a job that was running fails or completes the outside releaseLock will fail because of version conflict which means then any potential next execution from a retry call needs to wait for the ttl to expire. This adds release locks inside the runRollupJob where needed, although not the cleanest solution with it littered in a few places. Will go back later and see how we can clean up that part (i.e. return lock for outside release or something).



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
