### PR TITLE
Accept request parameters in RestGetRollupAction and fix flakey tests

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/action/get/GetRollupsRequest.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/action/get/GetRollupsRequest.kt
@@ -29,12 +29,13 @@ class GetRollupsRequest : ActionRequest {
     val size: Int
     val sortField: String
     val sortDirection: String
+
     constructor(
-        searchString: String = "",
-        from: Int = 0,
-        size: Int = 20,
-        sortField: String = "${Rollup.ROLLUP_TYPE}.${Rollup.ROLLUP_ID_FIELD}.keyword",
-        sortDirection: String = "asc"
+        searchString: String = DEFAULT_SEARCH_STRING,
+        from: Int = DEFAULT_FROM,
+        size: Int = DEFAULT_SIZE,
+        sortField: String = DEFAULT_SORT_FIELD,
+        sortDirection: String = DEFAULT_SORT_DIRECTION
     ) : super() {
         this.searchString = searchString
         this.from = from
@@ -61,5 +62,13 @@ class GetRollupsRequest : ActionRequest {
         out.writeInt(size)
         out.writeString(sortField)
         out.writeString(sortDirection)
+    }
+
+    companion object {
+        const val DEFAULT_SEARCH_STRING = ""
+        const val DEFAULT_FROM = 0
+        const val DEFAULT_SIZE = 20
+        const val DEFAULT_SORT_FIELD = "${Rollup.ROLLUP_TYPE}.${Rollup.ROLLUP_ID_FIELD}.keyword"
+        const val DEFAULT_SORT_DIRECTION = "asc"
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/resthandler/RestGetRollupAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/resthandler/RestGetRollupAction.kt
@@ -20,6 +20,11 @@ import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.action.get.G
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.action.get.GetRollupRequest
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.action.get.GetRollupsAction
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.action.get.GetRollupsRequest
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.action.get.GetRollupsRequest.Companion.DEFAULT_FROM
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.action.get.GetRollupsRequest.Companion.DEFAULT_SEARCH_STRING
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.action.get.GetRollupsRequest.Companion.DEFAULT_SIZE
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.action.get.GetRollupsRequest.Companion.DEFAULT_SORT_DIRECTION
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.action.get.GetRollupsRequest.Companion.DEFAULT_SORT_FIELD
 import org.elasticsearch.client.node.NodeClient
 import org.elasticsearch.rest.BaseRestHandler
 import org.elasticsearch.rest.RestHandler.Route
@@ -45,9 +50,21 @@ class RestGetRollupAction : BaseRestHandler() {
 
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val rollupID = request.param("rollupID")
+        val searchString = request.param("search", DEFAULT_SEARCH_STRING)
+        val from = request.paramAsInt("from", DEFAULT_FROM)
+        val size = request.paramAsInt("size", DEFAULT_SIZE)
+        val sortField = request.param("sortField", DEFAULT_SORT_FIELD)
+        val sortDirection = request.param("sortDirection", DEFAULT_SORT_DIRECTION)
         return RestChannelConsumer { channel ->
             if (rollupID == null || rollupID.isEmpty()) {
-                client.execute(GetRollupsAction.INSTANCE, GetRollupsRequest(), RestToXContentListener(channel))
+                val req = GetRollupsRequest(
+                    searchString,
+                    from,
+                    size,
+                    sortField,
+                    sortDirection
+                )
+                client.execute(GetRollupsAction.INSTANCE, req, RestToXContentListener(channel))
             } else {
                 val req = GetRollupRequest(rollupID, if (request.method() == HEAD) FetchSourceContext.DO_NOT_FETCH_SOURCE else null)
                 client.execute(GetRollupAction.INSTANCE, req, RestToXContentListener(channel))

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/resthandler/RestStopRollupActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/resthandler/RestStopRollupActionIT.kt
@@ -93,6 +93,8 @@ class RestStopRollupActionIT : RollupRestTestCase() {
             val updatedRollup = getRollup(rollup.id)
             val metadata = getRollupMetadata(updatedRollup.metadataID!!)
             assertEquals("Rollup never finished", RollupMetadata.Status.FINISHED, metadata.status)
+            // Waiting for job to be disabled here to avoid version conflict exceptions later on
+            assertFalse("Job was not disabled", updatedRollup.enabled)
         }
 
         // Try to stop a finished rollup


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* `RestGetRollupAction` was not taking in parameters to be passed into `GetRollupsRequest`, meaning only the default values could be used
* Due to the issue above, the integration test for getting all rollups would sometimes fail if the total number of rollup jobs at the time of the test exceeded `20` as this was the default response size
* Fixed a flakey test for the stop API that led to intermittent `version_conflict_exception`s since the rollup job was being updated when being disabled in between the time that the stop API was retrieving and updating the document

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
