### PR TITLE
move metadata to config index

### DIFF
--- a/.github/workflows/multi-node-test-workflow.yml
+++ b/.github/workflows/multi-node-test-workflow.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - master
+      - opendistro-1.11
   push:
     branches:
       - master
+      - opendistro-1.11
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ ext {
 }
 
 group = "com.amazon.opendistroforelasticsearch"
-version = "${opendistroVersion}.0"
+version = "${opendistroVersion}.1"
 
 if (isSnapshot) {
     version += "-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ apply plugin: 'java'
 apply plugin: 'jacoco'
 apply plugin: 'idea'
 apply plugin: 'elasticsearch.esplugin'
-apply plugin: 'elasticsearch.testclusters'
 apply plugin: 'io.gitlab.arturbosch.detekt'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'org.jetbrains.kotlin.plugin.allopen'
@@ -232,3 +231,34 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
 compileKotlin { kotlinOptions.freeCompilerArgs = ['-Xjsr305=strict'] }
 
 apply from: 'build-tools/pkgbuild.gradle'
+
+// setup for rolling upgrade test
+import org.elasticsearch.gradle.test.RestIntegTestTask
+
+def mixedClusterTest = project.tasks.create('mixedCluster', RestIntegTestTask.class)
+def mixedClusterFlag = findProperty('mixed') as Boolean ?: false
+
+testClusters.mixedCluster {
+    testDistribution = "OSS"
+    if (_numNodes > 1) numberOfNodes = _numNodes
+    getNodes().each { node ->
+        node.plugin(fileTree("src/test/resources/job-scheduler").getSingleFile())
+        node.plugin(project.tasks.bundlePlugin.archiveFile)
+
+        if (mixedClusterFlag && node.name == "mixedCluster-1") {
+            node.plugins.remove(1)
+            node.plugin(fileTree("src/test/resources/index-management").getSingleFile())
+            node.plugins.each { println("plugin in new node: $it") }
+        }
+    }
+    setting 'path.repo', repo.absolutePath
+}
+
+mixedClusterTest.dependsOn(bundlePlugin)
+
+mixedClusterTest.runner {
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty 'tests.path.repo', repo.absolutePath
+    systemProperty 'cluster.mixed', "$mixedClusterFlag"
+    systemProperty 'cluster.number_of_nodes', "${_numNodes}"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -232,7 +232,9 @@ compileKotlin { kotlinOptions.freeCompilerArgs = ['-Xjsr305=strict'] }
 
 apply from: 'build-tools/pkgbuild.gradle'
 
-// setup for rolling upgrade test
+// This IT is to simulate the situation
+// when there are old version (without metadata change)
+// and new version mixed in one cluster
 import org.elasticsearch.gradle.test.RestIntegTestTask
 
 def mixedClusterTest = project.tasks.create('mixedCluster', RestIntegTestTask.class)

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementHistory.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementHistory.kt
@@ -21,6 +21,7 @@ import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagemen
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.step.Step
+import com.amazon.opendistroforelasticsearch.indexmanagement.util.OpenForTesting
 import com.amazon.opendistroforelasticsearch.indexmanagement.util._DOC
 import org.apache.logging.log4j.LogManager
 import org.elasticsearch.action.DocWriteRequest
@@ -43,6 +44,7 @@ import org.elasticsearch.threadpool.Scheduler
 import org.elasticsearch.threadpool.ThreadPool
 import java.time.Instant
 
+@OpenForTesting
 class IndexStateManagementHistory(
     settings: Settings,
     private val client: Client,

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -17,13 +17,13 @@ package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanageme
 
 import com.amazon.opendistroforelasticsearch.indexmanagement.IndexManagementPlugin.Companion.INDEX_MANAGEMENT_INDEX
 import com.amazon.opendistroforelasticsearch.indexmanagement.IndexManagementIndices
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.contentParser
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.getClusterStateManagedIndexConfig
-import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.getManagedIndexMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.getPolicyID
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.mgetManagedIndexMetadata
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.retry
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.shouldCreateManagedIndexConfig
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.shouldDeleteManagedIndexConfig
-import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.shouldDeleteManagedIndexMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.suspendUntil
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.coordinator.ClusterStateManagedIndexConfig
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
@@ -35,13 +35,13 @@ import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagemen
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.JOB_INTERVAL
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.POLICY_ID
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings.Companion.SWEEP_PERIOD
-import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataAction
-import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataRequest
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.deleteManagedIndexMetadataRequest
 import com.amazon.opendistroforelasticsearch.indexmanagement.util.OpenForTesting
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.managedIndexConfigIndexRequest
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.deleteManagedIndexRequest
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.getCreateManagedIndexRequests
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.getDeleteManagedIndexRequests
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.getDeleteManagedIndices
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.getSweptManagedIndexSearchRequest
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.isFailed
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.isPolicyCompleted
@@ -61,22 +61,16 @@ import org.elasticsearch.action.bulk.BulkRequest
 import org.elasticsearch.action.bulk.BulkResponse
 import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.action.support.IndicesOptions
-import org.elasticsearch.action.support.master.AcknowledgedResponse
+import org.elasticsearch.action.update.UpdateRequest
 import org.elasticsearch.client.Client
 import org.elasticsearch.cluster.ClusterChangedEvent
 import org.elasticsearch.cluster.ClusterState
 import org.elasticsearch.cluster.ClusterStateListener
 import org.elasticsearch.cluster.LocalNodeMasterListener
 import org.elasticsearch.cluster.service.ClusterService
-import org.elasticsearch.common.bytes.BytesReference
 import org.elasticsearch.common.component.LifecycleListener
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.unit.TimeValue
-import org.elasticsearch.common.xcontent.LoggingDeprecationHandler
-import org.elasticsearch.common.xcontent.NamedXContentRegistry
-import org.elasticsearch.common.xcontent.XContentHelper
-import org.elasticsearch.common.xcontent.XContentParser
-import org.elasticsearch.common.xcontent.XContentType
 import org.elasticsearch.index.Index
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.threadpool.Scheduler
@@ -159,10 +153,9 @@ class ManagedIndexCoordinator(
     override fun clusterChanged(event: ClusterChangedEvent) {
         if (!isIndexStateManagementEnabled()) return
 
-        if (!event.localNodeMaster()) return
+        if (event.isNewCluster) return
 
-        // TODO: Look into event.isNewCluster, can we return early if true?
-        // if (event.isNewCluster) { }
+        if (!event.localNodeMaster()) return
 
         if (!event.metadataChanged()) return
 
@@ -199,73 +192,84 @@ class ManagedIndexCoordinator(
     }
 
     private suspend fun reenableJobs() {
+        /*
+         * Iterate through all indices and create update requests to update the ManagedIndexConfig for indices that
+         * meet the following conditions:
+         *   1. Is being managed ( has policyID in index settings ), then try to retrieve metadata from config index
+         *   2. Does not have a completed Policy
+         *   3. Does not have a failed Policy
+         */
+
         val clusterStateRequest = ClusterStateRequest()
             .clear()
             .metadata(true)
             .local(false)
             .indices("*")
             .indicesOptions(IndicesOptions.strictExpand())
-
         val response: ClusterStateResponse = client.admin().cluster().suspendUntil { state(clusterStateRequest, it) }
 
-        /*
-         * Iterate through all indices and create update requests to update the ManagedIndexConfig for indices that
-         * meet the following conditions:
-         *   1. Is being managed (has ManagedIndexMetaData)
-         *   2. Does not have a completed Policy
-         *   3. Does not have a failed Policy
-         */
-        val updateManagedIndicesRequests: List<DocWriteRequest<*>> = response.state.metadata.indices.mapNotNull {
-            val managedIndexMetaData = it.value.getManagedIndexMetaData()
-            if (!(managedIndexMetaData == null || managedIndexMetaData.isPolicyCompleted || managedIndexMetaData.isFailed)) {
-                updateEnableManagedIndexRequest(it.value.indexUUID)
-            } else {
-                null
+        val indicesWithPolicyID = mutableListOf<Index>()
+        response.state.metadata.indices.forEach {
+            if (it.value.getPolicyID() != null) {
+                indicesWithPolicyID.add(it.value.index)
             }
         }
 
-        updateManagedIndices(updateManagedIndicesRequests, false)
+        val enableManagedIndicesRequests = mutableListOf<UpdateRequest>()
+        val metadataList = client.mgetManagedIndexMetadata(indicesWithPolicyID)
+        metadataList.forEach {
+            if (it != null && !(it.isPolicyCompleted || it.isFailed)) {
+                enableManagedIndicesRequests.add(updateEnableManagedIndexRequest(it.indexUuid))
+            }
+        }
+
+        updateManagedIndices(enableManagedIndicesRequests, false)
     }
 
     private fun isIndexStateManagementEnabled(): Boolean = indexStateManagementEnabled == true
 
+    /** create, delete job document based on index's policyID setting changes */
     @OpenForTesting
-    suspend fun sweepClusterChangedEvent(event: ClusterChangedEvent) {
-        val indicesDeletedRequests = event.indicesDeleted()
-                    .filter { event.previousState().metadata().index(it)?.getPolicyID() != null }
-                    .map { deleteManagedIndexRequest(it.uuid) }
+    fun sweepClusterChangedEvent(event: ClusterChangedEvent) {
+        val managedIndicesDeleted = event.indicesDeleted()
+                .filter { event.previousState().metadata().index(it)?.getPolicyID() != null }
 
-        /*
-        * Update existing indices that have added or removed policy_ids
-        * There doesn't seem to be a fast way of finding indices that meet the above conditions without
-        * iterating over every index in cluster state and comparing current policy_id with previous policy_id
-        * If this turns out to be a performance bottle neck we can remove this and enforce
-        * addPolicy/removePolicy API usage for existing indices and let the background sweep pick up
-        * any changes from users that ignore and use the ES settings API
-        * */
-        var hasCreateRequests = false
-        val updateManagedIndicesRequests = mutableListOf<DocWriteRequest<*>>()
-        val indicesToRemoveManagedIndexMetaDataFrom = mutableListOf<Index>()
-        event.state().metadata().indices().forEach {
-            val previousIndexMetaData = event.previousState().metadata().index(it.value.index)
-            val policyID = it.value.getPolicyID()
-            val request: DocWriteRequest<*>? = when {
-                it.value.shouldCreateManagedIndexConfig(previousIndexMetaData) && policyID != null -> {
-                    hasCreateRequests = true
-                    managedIndexConfigIndexRequest(it.value.index.name, it.value.indexUUID, policyID, jobInterval)
+        launch {
+            val indicesDeletedRequests = managedIndicesDeleted.map { deleteManagedIndexRequest(it.uuid) }
+
+            /*
+            * Update existing indices that have added or removed policy_ids
+            * There doesn't seem to be a fast way of finding indices that meet the above conditions without
+            * iterating over every index in cluster state and comparing current policy_id with previous policy_id
+            * If this turns out to be a performance bottle neck we can remove this and enforce
+            * addPolicy/removePolicy API usage for existing indices and let the background sweep pick up
+            * any changes from users that ignore and use the ES settings API
+            * */
+            var hasCreateRequests = false
+            val updateManagedIndicesRequests = mutableListOf<DocWriteRequest<*>>()
+            event.state().metadata().indices().forEach {
+                val previousIndexMetaData = event.previousState().metadata().index(it.value.index)
+                val policyID = it.value.getPolicyID()
+                val request: DocWriteRequest<*>? = when {
+                    it.value.shouldCreateManagedIndexConfig(previousIndexMetaData) && policyID != null -> {
+                        hasCreateRequests = true
+                        managedIndexConfigIndexRequest(it.value.index.name, it.value.indexUUID, policyID, jobInterval)
+                    }
+                    it.value.shouldDeleteManagedIndexConfig(previousIndexMetaData) ->
+                        deleteManagedIndexRequest(it.value.indexUUID)
+                    else -> null
                 }
-                it.value.shouldDeleteManagedIndexConfig(previousIndexMetaData) ->
-                    deleteManagedIndexRequest(it.value.indexUUID)
-                else -> null
+                if (request != null) updateManagedIndicesRequests.add(request)
             }
 
-            if (request != null) updateManagedIndicesRequests.add(request)
-
-            if (it.value.shouldDeleteManagedIndexMetaData()) indicesToRemoveManagedIndexMetaDataFrom.add(it.value.index)
+            updateManagedIndices(updateManagedIndicesRequests + indicesDeletedRequests, hasCreateRequests)
         }
 
-        updateManagedIndices(updateManagedIndicesRequests + indicesDeletedRequests, hasCreateRequests)
-        clearManagedIndexMetaData(indicesToRemoveManagedIndexMetaDataFrom)
+        launch(CoroutineName("remove-metadata")) {
+            val indicesToRemoveMetadata = getIndicesToDeleteMetadataFrom(event.state()) + managedIndicesDeleted
+            val deleteRequests = indicesToRemoveMetadata.map { deleteManagedIndexMetadataRequest(it.uuid) }
+            clearManagedIndexMetaData(deleteRequests)
+        }
     }
 
     /**
@@ -324,15 +328,18 @@ class ManagedIndexCoordinator(
 
         val createManagedIndexRequests =
                 getCreateManagedIndexRequests(clusterStateManagedIndices, currentManagedIndices, jobInterval)
-
         val deleteManagedIndexRequests =
                 getDeleteManagedIndexRequests(clusterStateManagedIndices, currentManagedIndices)
-
-        val indicesToDeleteManagedIndexMetaDataFrom = getIndicesToDeleteManagedIndexMetaDataFrom(clusterService.state())
-
         val requests = createManagedIndexRequests + deleteManagedIndexRequests
+
         updateManagedIndices(requests, createManagedIndexRequests.isNotEmpty())
-        clearManagedIndexMetaData(indicesToDeleteManagedIndexMetaDataFrom)
+
+        // clear metadata
+        val indicesToDeleteMetadata =
+                getIndicesToDeleteMetadataFrom(clusterService.state()) + getDeleteManagedIndices(clusterStateManagedIndices, currentManagedIndices)
+        val deleteRequests = indicesToDeleteMetadata.map { deleteManagedIndexMetadataRequest(it.uuid) }
+        clearManagedIndexMetaData(deleteRequests)
+
         lastFullSweepTimeNano = System.nanoTime()
     }
 
@@ -357,11 +364,6 @@ class ManagedIndexCoordinator(
             it.id to SweptManagedIndexConfig.parseWithType(contentParser(it.sourceRef),
                     it.seqNo, it.primaryTerm)
         }.toMap()
-    }
-
-    private fun contentParser(bytesReference: BytesReference): XContentParser {
-        return XContentHelper.createParser(NamedXContentRegistry.EMPTY,
-                LoggingDeprecationHandler.INSTANCE, bytesReference, XContentType.JSON)
     }
 
     /**
@@ -398,7 +400,7 @@ class ManagedIndexCoordinator(
 
         retryPolicy.retry(logger, listOf(RestStatus.TOO_MANY_REQUESTS)) {
             val bulkRequest = BulkRequest().add(requestsToRetry)
-            val bulkResponse: BulkResponse = client.suspendUntil { client.bulk(bulkRequest, it) }
+            val bulkResponse: BulkResponse = client.suspendUntil { bulk(bulkRequest, it) }
             val failedResponses = (bulkResponse.items ?: arrayOf()).filter { it.isFailed }
             requestsToRetry = failedResponses.filter { it.status() == RestStatus.TOO_MANY_REQUESTS }
                     .map { bulkRequest.requests()[it.itemId] }
@@ -410,31 +412,50 @@ class ManagedIndexCoordinator(
         }
     }
 
-    /** Returns a list of [Index]es that need to have their [ManagedIndexMetaData] removed. */
-    @OpenForTesting
-    fun getIndicesToDeleteManagedIndexMetaDataFrom(clusterState: ClusterState): List<Index> {
-        return clusterState.metadata().indices().values().mapNotNull {
-            if (it.value.shouldDeleteManagedIndexMetaData()) it.value.index else null
+    /**
+     * Returns a list of [Index]es that need to have their [ManagedIndexMetaData] removed
+     * This method only consider policyID set to null situation
+     * index deleted situation is dealt in place, concatenate with this method's result
+     */
+    suspend fun getIndicesToDeleteMetadataFrom(clusterState: ClusterState): List<Index> {
+        val indicesWithNullPolicyID = mutableListOf<Index>()
+        clusterState.metadata().indices().values().forEach {
+            if (it.value.getPolicyID() == null) {
+                indicesWithNullPolicyID.add(it.value.index)
+            }
         }
+
+        return getIndicesToRemoveMetadataFrom(indicesWithNullPolicyID)
+    }
+
+    /** If this index has no policyID but [ManagedIndexMetaData] is not null then metadata should be removed. */
+    suspend fun getIndicesToRemoveMetadataFrom(indicesWithNullPolicyID: List<Index>): List<Index> {
+        val indicesToRemoveManagedIndexMetaDataFrom = mutableListOf<Index>()
+        val metadataList = client.mgetManagedIndexMetadata(indicesWithNullPolicyID)
+        metadataList.forEach {
+            if (it != null) indicesToRemoveManagedIndexMetaDataFrom.add(Index(it.index, it.indexUuid))
+        }
+        return indicesToRemoveManagedIndexMetaDataFrom
     }
 
     /** Removes the [ManagedIndexMetaData] from the given list of [Index]es. */
     @OpenForTesting
     @Suppress("TooGenericExceptionCaught")
-    suspend fun clearManagedIndexMetaData(indices: List<Index>) {
+    suspend fun clearManagedIndexMetaData(deleteRequests: List<DocWriteRequest<*>>) {
         try {
             // If list of indices is empty, no request necessary
-            if (indices.isEmpty()) return
-
-            val request = UpdateManagedIndexMetaDataRequest(indicesToRemoveManagedIndexMetaDataFrom = indices)
+            if (deleteRequests.isEmpty()) return
 
             retryPolicy.retry(logger) {
-                val response: AcknowledgedResponse = client.suspendUntil { execute(UpdateManagedIndexMetaDataAction.INSTANCE, request, it) }
-
-                if (!response.isAcknowledged) logger.error("Failed to remove ManagedIndexMetaData for [indices=$indices]")
+                val bulkRequest = BulkRequest().add(deleteRequests)
+                val bulkResponse: BulkResponse = client.suspendUntil { bulk(bulkRequest, it) }
+                bulkResponse.forEach {
+                    if (it.isFailed) logger.error("Failed to clear ManagedIndexMetadata for [index=${it.index}]. " +
+                            "Id: ${it.id}, failureMessage: ${it.failureMessage}")
+                }
             }
         } catch (e: Exception) {
-            logger.error("Failed to remove ManagedIndexMetaData for [indices=$indices]", e)
+            logger.error("Failed to clear ManagedIndexMetadata ", e)
         }
     }
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -187,14 +187,13 @@ object ManagedIndexRunner : ScheduledJobRunner,
     }
 
     override fun runJob(job: ScheduledJobParameter, context: JobExecutionContext) {
-        logger.info("start running")
         if (job !is ManagedIndexConfig) {
             throw IllegalArgumentException("Invalid job type, found ${job.javaClass.simpleName} with id: ${context.jobId}")
         }
 
         launch {
             if (skipExecFlag.flag) {
-                logger.info("cluster still has node running old ISM plugin, so skip execution on this node until all nodes upgraded")
+                logger.info("cluster still has node running old version ISM plugin, so skip execution on this node until all nodes upgraded")
                 return@launch
             }
 
@@ -628,7 +627,10 @@ object ManagedIndexRunner : ScheduledJobRunner,
     )
 
     /**
-     *  deal with still existing metadata in cluster state
+     *  only if metadata from config index is null and metadata from cluster state is not null
+     *  will try to update metadata from cluster state to config index, and clear metadata in cluster state
+     *  else when we have metadata in config index, we only try to clear metadata in cluster state if we
+     *  haven't cleared it successfully
      */
     @OpenForTesting
     suspend fun handleClusterStateMetadata(input: ManagedIndexMetaData?, metadataFromClusterState: ManagedIndexMetaData?): ManagedIndexMetaData? {

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -214,7 +214,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
 
     @Suppress("ReturnCount", "ComplexMethod", "LongMethod")
     private suspend fun runManagedIndexConfig(managedIndexConfig: ManagedIndexConfig) {
-        logger.info("try to run job for ${managedIndexConfig.index}")
+        logger.info("run job for index ${managedIndexConfig.index}")
         // doing a check of local cluster health as we do not want to overload master node with potentially a lot of calls
         if (clusterIsRed()) {
             logger.debug("Skipping current execution of ${managedIndexConfig.index} because of red cluster health")

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -53,9 +53,11 @@ import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagemen
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.isFailed
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.isSafeToChange
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.isSuccessfulDelete
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.managedIndexMetadataIndexRequest
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.shouldBackoff
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.shouldChangePolicy
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.util.updateDisableManagedIndexRequest
+import com.amazon.opendistroforelasticsearch.indexmanagement.util.OpenForTesting
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.JobExecutionContext
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.LockModel
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.ScheduledJobParameter
@@ -64,6 +66,7 @@ import com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule.IntervalS
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -96,6 +99,7 @@ import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.elasticsearch.common.xcontent.XContentType
 import org.elasticsearch.index.Index
 import org.elasticsearch.index.engine.VersionConflictEngineException
+import org.elasticsearch.index.seqno.SequenceNumbers
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.script.Script
 import org.elasticsearch.script.ScriptService
@@ -114,6 +118,8 @@ object ManagedIndexRunner : ScheduledJobRunner,
     private lateinit var xContentRegistry: NamedXContentRegistry
     private lateinit var scriptService: ScriptService
     private lateinit var settings: Settings
+    private lateinit var ismHistory: IndexStateManagementHistory
+    private lateinit var skipExecFlag: SkipExecution
     private var indexStateManagementEnabled: Boolean = DEFAULT_ISM_ENABLED
     @Suppress("MagicNumber")
     private val savePolicyRetryPolicy = BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(250), 3)
@@ -123,6 +129,8 @@ object ManagedIndexRunner : ScheduledJobRunner,
     private val errorNotificationRetryPolicy = BackoffPolicy.exponentialBackoff(TimeValue.timeValueMillis(250), 3)
     private var jobInterval: Int = DEFAULT_JOB_INTERVAL
     private var allowList: List<String> = ALLOW_LIST_NONE
+    // indicate whether metadata in cluster state is delete successful last time
+    var metadataDeleted: Boolean = true
 
     fun registerClusterService(clusterService: ClusterService): ManagedIndexRunner {
         this.clusterService = clusterService
@@ -168,22 +176,38 @@ object ManagedIndexRunner : ScheduledJobRunner,
         return this
     }
 
+    fun registerHistoryIndex(ismHistory: IndexStateManagementHistory): ManagedIndexRunner {
+        this.ismHistory = ismHistory
+        return this
+    }
+
+    fun registerSkipFlag(flag: SkipExecution): ManagedIndexRunner {
+        this.skipExecFlag = flag
+        return this
+    }
+
     override fun runJob(job: ScheduledJobParameter, context: JobExecutionContext) {
+        logger.info("start running")
         if (job !is ManagedIndexConfig) {
             throw IllegalArgumentException("Invalid job type, found ${job.javaClass.simpleName} with id: ${context.jobId}")
         }
 
         launch {
+            if (skipExecFlag.flag) {
+                logger.info("cluster still has node running old ISM plugin, so skip execution on this node until all nodes upgraded")
+                return@launch
+            }
+
             // Attempt to acquire lock
             val lock: LockModel? = context.lockService.suspendUntil { acquireLock(job, context, it) }
             if (lock == null) {
-                logger.debug("Could not acquire lock for ${job.index}")
+                logger.debug("Could not acquire lock [${lock?.lockId}] for ${job.index}")
             } else {
                 runManagedIndexConfig(job)
                 // Release lock
                 val released: Boolean = context.lockService.suspendUntil { release(lock, it) }
                 if (!released) {
-                    logger.debug("Could not release lock for ${job.index}")
+                    logger.debug("Could not release lock [${lock.lockId}] for ${job.index}")
                 }
             }
         }
@@ -197,15 +221,14 @@ object ManagedIndexRunner : ScheduledJobRunner,
             return
         }
 
-        // Get current IndexMetaData and ManagedIndexMetaData
-        val indexMetaData = getIndexMetaData(managedIndexConfig.index)
-        if (indexMetaData == null) {
-            return
-        }
-        val managedIndexMetaData = indexMetaData.getManagedIndexMetaData()
+        val indexMetaData = getIndexMetadata(managedIndexConfig.index) ?: return
+        var managedIndexMetaData = indexMetaData.getManagedIndexMetaData(client)
+        val metadataFromClusterState = indexMetaData.getManagedIndexMetaData()
+        managedIndexMetaData = handleClusterStateMetadata(managedIndexMetaData, metadataFromClusterState)
 
         // If policy or managedIndexMetaData is null then initialize
         val policy = managedIndexConfig.policy
+
         if (policy == null || managedIndexMetaData == null) {
             initManagedIndex(managedIndexConfig, managedIndexMetaData)
             return
@@ -226,8 +249,14 @@ object ManagedIndexRunner : ScheduledJobRunner,
 
         if (managedIndexMetaData.hasVersionConflict(managedIndexConfig)) {
             val info = mapOf("message" to "There is a version conflict between your previous execution and your managed index")
-            val updated = updateManagedIndexMetaData(managedIndexMetaData.copy(policyRetryInfo = PolicyRetryInfoMetaData(true, 0), info = info))
-            if (updated) disableManagedIndexConfig(managedIndexConfig)
+            val result = updateManagedIndexMetaData(
+                managedIndexMetaData.copy(
+                    policyRetryInfo = PolicyRetryInfoMetaData(true, 0),
+                    info = info
+                ))
+            if (result.savedMetadata) {
+                disableManagedIndexConfig(managedIndexConfig)
+            }
             return
         }
 
@@ -248,7 +277,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
             logger.error("Action=${action.type.type} has timed out")
             val updated = updateManagedIndexMetaData(managedIndexMetaData
                 .copy(actionMetaData = currentActionMetaData?.copy(failed = true), info = info))
-            if (updated) disableManagedIndexConfig(managedIndexConfig)
+            if (updated.savedMetadata) disableManagedIndexConfig(managedIndexConfig)
             return
         }
 
@@ -269,8 +298,9 @@ object ManagedIndexRunner : ScheduledJobRunner,
             logger.info("Previous execution failed to update step status, isIdempotent=$isIdempotent")
             if (isIdempotent != true) {
                 val info = mapOf("message" to "Previous action was not able to update IndexMetaData.")
-                val updated = updateManagedIndexMetaData(managedIndexMetaData.copy(policyRetryInfo = PolicyRetryInfoMetaData(true, 0), info = info))
-                if (updated) disableManagedIndexConfig(managedIndexConfig)
+                val updated = updateManagedIndexMetaData(managedIndexMetaData.copy(
+                        policyRetryInfo = PolicyRetryInfoMetaData(true, 0), info = info))
+                if (updated.savedMetadata) disableManagedIndexConfig(managedIndexConfig)
                 return
             }
         }
@@ -279,8 +309,9 @@ object ManagedIndexRunner : ScheduledJobRunner,
         // as this action has been removed from the AllowList, but if its not the first step we will let it finish as it's already inflight
         if (action?.isAllowed(allowList) == false && action.isFirstStep(step?.name)) {
             val info = mapOf("message" to "Attempted to execute action=${action.type.type} which is not allowed.")
-            val updated = updateManagedIndexMetaData(managedIndexMetaData.copy(policyRetryInfo = PolicyRetryInfoMetaData(true, 0), info = info))
-            if (updated) disableManagedIndexConfig(managedIndexConfig)
+            val updated = updateManagedIndexMetaData(managedIndexMetaData.copy(
+                    policyRetryInfo = PolicyRetryInfoMetaData(true, 0), info = info))
+            if (updated.savedMetadata) disableManagedIndexConfig(managedIndexConfig)
             return
         }
 
@@ -288,7 +319,8 @@ object ManagedIndexRunner : ScheduledJobRunner,
         val startingManagedIndexMetaData = managedIndexMetaData.getStartingManagedIndexMetaData(state, action, step)
         val updateResult = updateManagedIndexMetaData(startingManagedIndexMetaData)
 
-        if (updateResult && state != null && action != null && step != null && currentActionMetaData != null) {
+        @Suppress("ComplexCondition")
+        if (updateResult.savedMetadata && state != null && action != null && step != null && currentActionMetaData != null) {
             // Step null check is done in getStartingManagedIndexMetaData
             step.preExecute(logger).execute().postExecute(logger)
             var executedManagedIndexMetaData = startingManagedIndexMetaData.getCompletedManagedIndexMetaData(action, step)
@@ -310,7 +342,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
                 return
             }
 
-            if (!updateManagedIndexMetaData(executedManagedIndexMetaData)) {
+            if (!updateManagedIndexMetaData(executedManagedIndexMetaData, updateResult).savedMetadata) {
                 logger.error("Failed to update ManagedIndexMetaData after executing the Step : ${step.name}")
             }
 
@@ -324,7 +356,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
         var policy: Policy? = managedIndexConfig.policy
         val policyID = managedIndexConfig.changePolicy?.policyID ?: managedIndexConfig.policyID
         // If policy does not currently exist, we need to save the policy on the ManagedIndexConfig for the first time
-        // or if a change policy exists then we will also execute the change as we are still in initialization phase
+        // or if a change policyID exists, it means user want to change policy before initialization phase
         if (policy == null || managedIndexConfig.changePolicy != null) {
             // Get the policy by the name unless a ChangePolicy exists then allow the change to happen during initialization
             policy = getPolicy(policyID)
@@ -493,7 +525,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
                 )
             else ->
                 // else this means we either tried to load a policy with a different id, seqno, or primaryterm from what is
-                // in the metadata and we cannot gaurantee it will work with the current state in managedIndexMetaData
+                // in the metadata and we cannot guarantee it will work with the current state in managedIndexMetaData
                 managedIndexMetaData.copy(
                     policyRetryInfo = PolicyRetryInfoMetaData(failed = true, consumedRetries = 0),
                     info = mapOf("message" to "Fail to load policy: ${policy.id} with " +
@@ -504,8 +536,9 @@ object ManagedIndexRunner : ScheduledJobRunner,
         }
     }
 
+    // update metadata in cluster state
     @Suppress("TooGenericExceptionCaught")
-    private suspend fun updateManagedIndexMetaData(managedIndexMetaData: ManagedIndexMetaData): Boolean {
+    private suspend fun updateManagedIndexMetaDataOld(managedIndexMetaData: ManagedIndexMetaData): Boolean {
         var result = false
         try {
             val request = UpdateManagedIndexMetaDataRequest(
@@ -529,11 +562,100 @@ object ManagedIndexRunner : ScheduledJobRunner,
         return result
     }
 
+    // delete metadata in cluster state
+    private suspend fun deleteManagedIndexMetaData(managedIndexMetaData: ManagedIndexMetaData): Boolean {
+        var result = false
+        try {
+            val request = UpdateManagedIndexMetaDataRequest(
+                indicesToRemoveManagedIndexMetaDataFrom = listOf(Index(managedIndexMetaData.index, managedIndexMetaData.indexUuid))
+            )
+            updateMetaDataRetryPolicy.retry(logger) {
+                val response: AcknowledgedResponse = client.suspendUntil { execute(UpdateManagedIndexMetaDataAction.INSTANCE, request, it) }
+                if (response.isAcknowledged) {
+                    result = true
+                } else {
+                    logger.error("Failed to delete ManagedIndexMetaData for [index=${managedIndexMetaData.index}]")
+                }
+            }
+        } catch (e: ClusterBlockException) {
+            logger.error("There was ClusterBlockException trying to delete the metadata for ${managedIndexMetaData.index}. Message: ${e.message}", e)
+        } catch (e: Exception) {
+            logger.error("Failed to delete ManagedIndexMetaData for [index=${managedIndexMetaData.index}]", e)
+        }
+        return result
+    }
+
+    // update metadata in config index, and save metadata in history after update
+    // we can possibly call this 2 times in one job run, so need to save seqNo & primeTerm for the second call
+    private suspend fun updateManagedIndexMetaData(
+        managedIndexMetaData: ManagedIndexMetaData,
+        lastUpdateResult: UpdateMetadataResult? = null
+    ): UpdateMetadataResult {
+        val result = UpdateMetadataResult()
+
+        var metadata: ManagedIndexMetaData = managedIndexMetaData
+        if (lastUpdateResult != null) {
+            metadata = managedIndexMetaData.copy(seqNo = lastUpdateResult.seqNo, primaryTerm = lastUpdateResult.primaryTerm)
+        }
+
+        val indexRequest = managedIndexMetadataIndexRequest(metadata)
+        try {
+            updateMetaDataRetryPolicy.retry(logger) {
+                val indexResponse: IndexResponse = client.suspendUntil { index(indexRequest, it) }
+                result.savedMetadata = indexResponse.status() ==
+                        RestStatus.OK || indexResponse.status() == RestStatus.CREATED
+                result.seqNo = indexResponse.seqNo
+                result.primaryTerm = indexResponse.primaryTerm
+            }
+
+            GlobalScope.launch(Dispatchers.IO + CoroutineName("ManagedIndexMetaData-AddHistory")) {
+                ismHistory.addManagedIndexMetaDataHistory(listOf(metadata))
+            }
+        } catch (e: VersionConflictEngineException) {
+            logger.error("There was VersionConflictEngineException trying to update the metadata for " +
+                    "${managedIndexMetaData.index}. Message: ${e.message}", e)
+        } catch (e: Exception) {
+            logger.error("Failed to save ManagedIndexMetaData for [index=${managedIndexMetaData.index}]", e)
+        }
+
+        return result
+    }
+
+    data class UpdateMetadataResult(
+        var savedMetadata: Boolean = false,
+        var seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
+        var primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+    )
+
+    /**
+     *  deal with still existing metadata in cluster state
+     */
+    @OpenForTesting
+    suspend fun handleClusterStateMetadata(input: ManagedIndexMetaData?, metadataFromClusterState: ManagedIndexMetaData?): ManagedIndexMetaData? {
+        var metadata: ManagedIndexMetaData? = input
+        if (metadataFromClusterState != null) {
+            if (metadata == null) {
+                // move metadata from cluster state metadata to config index
+                metadata = metadataFromClusterState
+                if (updateManagedIndexMetaData(metadata).savedMetadata) {
+                    metadataDeleted = deleteManagedIndexMetaData(metadataFromClusterState)
+                }
+            } else {
+                if (!metadataDeleted) {
+                    // fail to delete cluster state metadata last time
+                    metadataDeleted = deleteManagedIndexMetaData(metadataFromClusterState)
+                }
+            }
+        }
+
+        return metadata
+    }
+
     /**
      * Initializes the change policy process where we will get the policy using the change policy's policyID, update the [ManagedIndexMetaData]
      * to reflect the new policy, and save the new policy to the [ManagedIndexConfig] while resetting the change policy to null
      */
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "ComplexMethod")
     private suspend fun initChangePolicy(
         managedIndexConfig: ManagedIndexConfig,
         managedIndexMetaData: ManagedIndexMetaData,
@@ -600,7 +722,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
         * */
         val updated = updateManagedIndexMetaData(updatedManagedIndexMetaData)
 
-        if (!updated || policy == null) return
+        if (!updated.savedMetadata || policy == null) return
 
         // this will save the new policy on the job and reset the change policy back to null
         val saved = savePolicyToManagedIndexConfig(managedIndexConfig, policy)
@@ -678,7 +800,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
 
     private fun clusterIsRed(): Boolean = ClusterStateHealth(clusterService.state()).status == ClusterHealthStatus.RED
 
-    private suspend fun getIndexMetaData(index: String): IndexMetadata? {
+    private suspend fun getIndexMetadata(index: String): IndexMetadata? {
         var indexMetaData: IndexMetadata? = null
         try {
             val clusterStateRequest = ClusterStateRequest()

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexRunner.kt
@@ -214,6 +214,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
 
     @Suppress("ReturnCount", "ComplexMethod", "LongMethod")
     private suspend fun runManagedIndexConfig(managedIndexConfig: ManagedIndexConfig) {
+        logger.info("try to run job for ${managedIndexConfig.index}")
         // doing a check of local cluster health as we do not want to overload master node with potentially a lot of calls
         if (clusterIsRed()) {
             logger.debug("Skipping current execution of ${managedIndexConfig.index} because of red cluster health")
@@ -352,6 +353,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
     }
 
     private suspend fun initManagedIndex(managedIndexConfig: ManagedIndexConfig, managedIndexMetaData: ManagedIndexMetaData?) {
+        logger.info("init for ${managedIndexConfig.index}, policy ${managedIndexConfig.policyID}")
         var policy: Policy? = managedIndexConfig.policy
         val policyID = managedIndexConfig.changePolicy?.policyID ?: managedIndexConfig.policyID
         // If policy does not currently exist, we need to save the policy on the ManagedIndexConfig for the first time
@@ -361,6 +363,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
             policy = getPolicy(policyID)
             // Attempt to save the policy
             if (policy != null) {
+                logger.info("attempt to save policy to config index")
                 val saved = savePolicyToManagedIndexConfig(managedIndexConfig, policy)
                 // If we failed to save the policy, don't initialize ManagedIndexMetaData
                 if (!saved) return
@@ -375,6 +378,7 @@ object ManagedIndexRunner : ScheduledJobRunner,
             // Initializing ManagedIndexMetaData for the first time
             getInitializedManagedIndexMetaData(managedIndexMetaData, managedIndexConfig, policy)
         }
+        logger.info("init metadata to update: $updatedManagedIndexMetaData")
 
         updateManagedIndexMetaData(updatedManagedIndexMetaData)
     }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/SkipExecution.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/SkipExecution.kt
@@ -33,27 +33,26 @@ class SkipExecution(
     }
 
     fun sweepISMPluginVersion() {
-        // if old node exits, set skip flag to true
+        // if old version ISM plugin exits (2 versions ISM in one cluster), set skip flag to true
         val request = NodesInfoRequest().clear().addMetric("plugins")
-        client.execute(NodesInfoAction.INSTANCE, request,
-                object : ActionListener<NodesInfoResponse> {
-                    override fun onResponse(response: NodesInfoResponse) {
-                        flag = false
-                        val versionSet = mutableSetOf<String>()
-                        for (node in response.nodes) {
-                            val pluginsInfo = node.getInfo(PluginsAndModules::class.java).pluginInfos
-                            pluginsInfo.forEach {
-                                if (it.name == "opendistro_index_management") {
-                                    versionSet.add(it.version)
-                                    if (versionSet.size > 1) flag = true
-                                }
-                            }
+        client.execute(NodesInfoAction.INSTANCE, request, object : ActionListener<NodesInfoResponse> {
+            override fun onResponse(response: NodesInfoResponse) {
+                flag = false
+                val versionSet = mutableSetOf<String>()
+                for (node in response.nodes) {
+                    val pluginsInfo = node.getInfo(PluginsAndModules::class.java).pluginInfos
+                    pluginsInfo.forEach {
+                        if (it.name == "opendistro_index_management") {
+                            versionSet.add(it.version)
+                            if (versionSet.size > 1) flag = true
                         }
                     }
+                }
+            }
 
-                    override fun onFailure(e: Exception) {
-                        logger.error("failed when get node info for setting skip flag: $e")
-                    }
-                })
+            override fun onFailure(e: Exception) {
+                logger.error("failed when get node info for setting skip flag: $e")
+            }
+        })
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/SkipExecution.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/SkipExecution.kt
@@ -1,0 +1,59 @@
+package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement
+
+import com.amazon.opendistroforelasticsearch.indexmanagement.util.OpenForTesting
+import org.apache.logging.log4j.LogManager
+import org.elasticsearch.action.ActionListener
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse
+import org.elasticsearch.action.admin.cluster.node.info.PluginsAndModules
+import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.ClusterChangedEvent
+import org.elasticsearch.cluster.ClusterStateListener
+import org.elasticsearch.cluster.service.ClusterService
+
+@OpenForTesting
+class SkipExecution(
+    private val client: Client,
+    private val clusterService: ClusterService
+) : ClusterStateListener {
+    private val logger = LogManager.getLogger(javaClass)
+
+    final var flag: Boolean = false
+        private set
+
+    init {
+        clusterService.addListener(this)
+    }
+
+    override fun clusterChanged(event: ClusterChangedEvent) {
+        if (event.nodesChanged() || event.isNewCluster) {
+            sweepISMPluginVersion()
+        }
+    }
+
+    fun sweepISMPluginVersion() {
+        // if old node exits, set skip flag to true
+        val request = NodesInfoRequest().clear().addMetric("plugins")
+        client.execute(NodesInfoAction.INSTANCE, request,
+                object : ActionListener<NodesInfoResponse> {
+                    override fun onResponse(response: NodesInfoResponse) {
+                        flag = false
+                        val versionSet = mutableSetOf<String>()
+                        for (node in response.nodes) {
+                            val pluginsInfo = node.getInfo(PluginsAndModules::class.java).pluginInfos
+                            pluginsInfo.forEach {
+                                if (it.name == "opendistro_index_management") {
+                                    versionSet.add(it.version)
+                                    if (versionSet.size > 1) flag = true
+                                }
+                            }
+                        }
+                    }
+
+                    override fun onFailure(e: Exception) {
+                        logger.error("failed when get node info for setting skip flag: $e")
+                    }
+                })
+    }
+}

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/elasticapi/ElasticExtensions.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/elasticapi/ElasticExtensions.kt
@@ -87,6 +87,7 @@ fun XContentBuilder.optionalTimeField(name: String, instant: Instant?): XContent
     return this.timeField(name, name, instant.toEpochMilli())
 }
 
+// forIndex means for saving to config index, distinguish from Explain and History, which only save meaningful partial metadata
 @Suppress("ReturnCount")
 fun XContentBuilder.addObject(name: String, metadata: ToXContentFragment?, params: ToXContent.Params, forIndex: Boolean = false): XContentBuilder {
     if (!forIndex) {
@@ -96,6 +97,7 @@ fun XContentBuilder.addObject(name: String, metadata: ToXContentFragment?, param
             this
         }
     }
+    // else: save to config index
     if (metadata != null) {
         return this.buildMetadata(name, metadata, params)
     }
@@ -273,9 +275,9 @@ suspend fun IndexMetadata.getManagedIndexMetaData(client: Client): ManagedIndexM
 
         return withContext(Dispatchers.IO) {
             val xcp = XContentHelper.createParser(
-                    NamedXContentRegistry.EMPTY,
-                    LoggingDeprecationHandler.INSTANCE,
-                    getResponse.sourceAsBytesRef, XContentType.JSON)
+                NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE,
+                getResponse.sourceAsBytesRef, XContentType.JSON)
             ManagedIndexMetaData.parseWithType(xcp, getResponse.id, getResponse.seqNo, getResponse.primaryTerm)
         }
     } catch (e: Exception) {

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/elasticapi/ElasticExtensions.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/elasticapi/ElasticExtensions.kt
@@ -268,6 +268,7 @@ fun DefaultShardOperationFailedException.getUsefulCauseString(): String {
 suspend fun IndexMetadata.getManagedIndexMetaData(client: Client): ManagedIndexMetaData? {
     try {
         val getRequest = GetRequest(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, indexUUID + "metadata")
+            .routing(this.indexUUID)
         val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
         if (!getResponse.isExists || getResponse.isSourceEmpty) {
             return null
@@ -300,7 +301,8 @@ suspend fun Client.mgetManagedIndexMetadata(indices: List<Index>): List<ManagedI
 
     val mgetRequest = MultiGetRequest()
     indices.forEach {
-        mgetRequest.add(MultiGetRequest.Item(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, it.uuid + "metadata"))
+        mgetRequest.add(MultiGetRequest.Item(
+            IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, it.uuid + "metadata").routing(it.uuid))
     }
     var mgetMetadataList = mutableListOf<ManagedIndexMetaData?>()
     try {
@@ -331,7 +333,8 @@ fun mgetResponseToList(mgetResponse: MultiGetResponse): MutableList<ManagedIndex
 fun buildMgetMetadataRequest(clusterState: ClusterState): MultiGetRequest {
     val mgetMetadataRequest = MultiGetRequest()
     clusterState.metadata.indices.map { it.value.index }.forEach {
-        mgetMetadataRequest.add(MultiGetRequest.Item(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, it.uuid + "metadata"))
+        mgetMetadataRequest.add(MultiGetRequest.Item(
+            IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, it.uuid + "metadata").routing(it.uuid))
     }
     return mgetMetadataRequest
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/elasticapi/ElasticExtensions.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/elasticapi/ElasticExtensions.kt
@@ -17,32 +17,51 @@
 
 package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi
 
+import com.amazon.opendistroforelasticsearch.indexmanagement.IndexManagementPlugin
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.coordinator.ClusterStateManagedIndexConfig
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
 import com.amazon.opendistroforelasticsearch.jobscheduler.spi.utils.LockService
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.elasticsearch.ElasticsearchException
 import org.elasticsearch.ExceptionsHelper
 import org.elasticsearch.action.ActionListener
+import org.elasticsearch.action.ActionRequestValidationException
+import org.elasticsearch.action.NoShardAvailableActionException
 import org.elasticsearch.action.bulk.BackoffPolicy
+import org.elasticsearch.action.get.GetRequest
+import org.elasticsearch.action.get.GetResponse
+import org.elasticsearch.action.get.MultiGetRequest
+import org.elasticsearch.action.get.MultiGetResponse
 import org.elasticsearch.action.support.DefaultShardOperationFailedException
+import org.elasticsearch.client.Client
 import org.elasticsearch.client.ElasticsearchClient
+import org.elasticsearch.cluster.ClusterState
 import org.elasticsearch.cluster.metadata.IndexMetadata
 import org.elasticsearch.common.bytes.BytesReference
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
 import org.elasticsearch.common.xcontent.ToXContent
+import org.elasticsearch.common.xcontent.ToXContentFragment
 import org.elasticsearch.common.xcontent.XContentBuilder
 import org.elasticsearch.common.xcontent.XContentHelper
 import org.elasticsearch.common.xcontent.XContentParser
 import org.elasticsearch.common.xcontent.XContentParserUtils
 import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.index.Index
+import org.elasticsearch.index.IndexNotFoundException
 import org.elasticsearch.rest.RestStatus
 import org.elasticsearch.transport.RemoteTransportException
 import java.time.Instant
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+
+private val logger = LogManager.getLogger("ElasticExtension")
 
 /** Convert an object to maps and lists representation */
 fun ToXContent.convertToMap(): Map<String, Any> {
@@ -66,6 +85,28 @@ fun XContentBuilder.optionalTimeField(name: String, instant: Instant?): XContent
         return nullField(name)
     }
     return this.timeField(name, name, instant.toEpochMilli())
+}
+
+@Suppress("ReturnCount")
+fun XContentBuilder.addObject(name: String, metadata: ToXContentFragment?, params: ToXContent.Params, forIndex: Boolean = false): XContentBuilder {
+    if (!forIndex) {
+        return if (metadata != null) {
+            return this.buildMetadata(name, metadata, params)
+        } else {
+            this
+        }
+    }
+    if (metadata != null) {
+        return this.buildMetadata(name, metadata, params)
+    }
+    return nullField(name)
+}
+
+fun XContentBuilder.buildMetadata(name: String, metadata: ToXContentFragment, params: ToXContent.Params): XContentBuilder {
+    this.startObject(name)
+    metadata.toXContent(this, params)
+    this.endObject()
+    return this
 }
 
 /**
@@ -176,15 +217,6 @@ fun IndexMetadata.shouldDeleteManagedIndexConfig(previousIndexMetaData: IndexMet
 }
 
 /**
- * Checks to see if the [ManagedIndexMetaData] should be removed.
- *
- * If [getPolicyID] returns null but [ManagedIndexMetaData] is not null then the policy was removed and
- * the [ManagedIndexMetaData] remains and should be removed.
- */
-fun IndexMetadata.shouldDeleteManagedIndexMetaData(): Boolean =
-    this.getPolicyID() == null && this.getManagedIndexMetaData() != null
-
-/**
  * Returns the current policy_id if it exists and is valid otherwise returns null.
  * */
 fun IndexMetadata.getPolicyID(): String? {
@@ -211,7 +243,7 @@ fun IndexMetadata.getClusterStateManagedIndexConfig(): ClusterStateManagedIndexC
 }
 
 fun IndexMetadata.getManagedIndexMetaData(): ManagedIndexMetaData? {
-    val existingMetaDataMap = this.getCustomData(ManagedIndexMetaData.MANAGED_INDEX_METADATA)
+    val existingMetaDataMap = this.getCustomData(ManagedIndexMetaData.MANAGED_INDEX_METADATA_TYPE)
 
     if (existingMetaDataMap != null) {
         return ManagedIndexMetaData.fromMap(existingMetaDataMap)
@@ -227,4 +259,82 @@ fun Throwable.findRemoteTransportException(): RemoteTransportException? {
 fun DefaultShardOperationFailedException.getUsefulCauseString(): String {
     val rte = this.cause?.findRemoteTransportException()
     return if (rte == null) this.toString() else ExceptionsHelper.unwrapCause(rte).toString()
+}
+
+// get metadata from config index using doc id
+@Suppress("ReturnCount")
+suspend fun IndexMetadata.getManagedIndexMetaData(client: Client): ManagedIndexMetaData? {
+    try {
+        val getRequest = GetRequest(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, indexUUID + "metadata")
+        val getResponse: GetResponse = client.suspendUntil { get(getRequest, it) }
+        if (!getResponse.isExists || getResponse.isSourceEmpty) {
+            return null
+        }
+
+        return withContext(Dispatchers.IO) {
+            val xcp = XContentHelper.createParser(
+                    NamedXContentRegistry.EMPTY,
+                    LoggingDeprecationHandler.INSTANCE,
+                    getResponse.sourceAsBytesRef, XContentType.JSON)
+            ManagedIndexMetaData.parseWithType(xcp, getResponse.id, getResponse.seqNo, getResponse.primaryTerm)
+        }
+    } catch (e: Exception) {
+        when (e) {
+            is IndexNotFoundException, is NoShardAvailableActionException -> {
+                logger.error("Failed to get metadata because no index or shard not available")
+            }
+            else -> logger.error("Failed to get metadata", e)
+        }
+
+        return null
+    }
+}
+
+/** multi-get metadata for indices */
+suspend fun Client.mgetManagedIndexMetadata(indices: List<Index>): List<ManagedIndexMetaData?> {
+    logger.debug("trying to get back metadata for indices ${indices.map { it.name }}")
+
+    if (indices.isEmpty()) return emptyList()
+
+    val mgetRequest = MultiGetRequest()
+    indices.forEach {
+        mgetRequest.add(MultiGetRequest.Item(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, it.uuid + "metadata"))
+    }
+    var mgetMetadataList = mutableListOf<ManagedIndexMetaData?>()
+    try {
+        val response: MultiGetResponse = this.suspendUntil { multiGet(mgetRequest, it) }
+        mgetMetadataList = mgetResponseToList(response)
+    } catch (e: ActionRequestValidationException) {
+        logger.info("No documents to get back metadata, ${e.message}")
+    }
+    return mgetMetadataList
+}
+
+/** transform multi-get response to list for ManagedIndexMetaData */
+fun mgetResponseToList(mgetResponse: MultiGetResponse): MutableList<ManagedIndexMetaData?> {
+    val mgetList = mutableListOf<ManagedIndexMetaData?>()
+    mgetResponse.responses.forEach {
+        if (it.response != null && !it.response.isSourceEmpty) {
+            val xcp = contentParser(it.response.sourceAsBytesRef)
+            mgetList.add(ManagedIndexMetaData.parseWithType(
+                    xcp, it.response.id, it.response.seqNo, it.response.primaryTerm))
+        } else {
+            mgetList.add(null)
+        }
+    }
+
+    return mgetList
+}
+
+fun buildMgetMetadataRequest(clusterState: ClusterState): MultiGetRequest {
+    val mgetMetadataRequest = MultiGetRequest()
+    clusterState.metadata.indices.map { it.value.index }.forEach {
+        mgetMetadataRequest.add(MultiGetRequest.Item(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, it.uuid + "metadata"))
+    }
+    return mgetMetadataRequest
+}
+
+fun contentParser(bytesReference: BytesReference): XContentParser {
+    return XContentHelper.createParser(NamedXContentRegistry.EMPTY,
+            LoggingDeprecationHandler.INSTANCE, bytesReference, XContentType.JSON)
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/model/ManagedIndexMetaData.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/model/ManagedIndexMetaData.kt
@@ -76,7 +76,7 @@ data class ManagedIndexMetaData(
     }
 
     fun toXContent(builder: XContentBuilder, params: ToXContent.Params, forIndex: Boolean): XContentBuilder {
-        // forIndex means for config index, distinguish for Explain and History
+        // forIndex means for saving to config index, distinguish from Explain and History, which only save meaningful partial metadata
         if (!forIndex) return toXContent(builder, params)
 
         builder

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/model/ManagedIndexMetaData.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/model/ManagedIndexMetaData.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model
 
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.elasticapi.addObject
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.action.ActionConfig
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.ActionMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.PolicyRetryInfoMetaData
@@ -33,6 +34,8 @@ import org.elasticsearch.common.xcontent.XContentParser
 import org.elasticsearch.common.xcontent.XContentParser.Token
 import org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken
 import org.elasticsearch.common.xcontent.json.JsonXContent
+import org.elasticsearch.index.seqno.SequenceNumbers
+import java.io.IOException
 
 data class ManagedIndexMetaData(
     val index: String,
@@ -47,7 +50,10 @@ data class ManagedIndexMetaData(
     val actionMetaData: ActionMetaData?,
     val stepMetaData: StepMetaData?,
     val policyRetryInfo: PolicyRetryInfoMetaData?,
-    val info: Map<String, Any>?
+    val info: Map<String, Any>?,
+    val id: String = NO_ID,
+    val seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
+    val primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
 ) : Writeable, ToXContentFragment {
 
     fun toMap(): Map<String, String> {
@@ -69,6 +75,31 @@ data class ManagedIndexMetaData(
         return resultMap
     }
 
+    fun toXContent(builder: XContentBuilder, params: ToXContent.Params, forIndex: Boolean): XContentBuilder {
+        // forIndex means for config index, distinguish for Explain and History
+        if (!forIndex) return toXContent(builder, params)
+
+        builder
+            .startObject()
+                .startObject(MANAGED_INDEX_METADATA_TYPE)
+                    .field(INDEX, index)
+                    .field(INDEX_UUID, indexUuid)
+                    .field(POLICY_ID, policyID)
+                    .field(POLICY_SEQ_NO, policySeqNo)
+                    .field(POLICY_PRIMARY_TERM, policyPrimaryTerm)
+                    .field(POLICY_COMPLETED, policyCompleted)
+                    .field(ROLLED_OVER, rolledOver)
+                    .field(TRANSITION_TO, transitionTo)
+                    .addObject(StateMetaData.STATE, stateMetaData, params, true)
+                    .addObject(ActionMetaData.ACTION, actionMetaData, params, true)
+                    .addObject(StepMetaData.STEP, stepMetaData, params, true)
+                    .addObject(PolicyRetryInfoMetaData.RETRY_INFO, policyRetryInfo, params, true)
+                    .field(INFO, info)
+                .endObject()
+            .endObject()
+        return builder
+    }
+
     @Suppress("ComplexMethod")
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
         // The order we check values matters here as we are only trying to show what is needed for the customer
@@ -77,7 +108,6 @@ data class ManagedIndexMetaData(
             .field(INDEX, index)
             .field(INDEX_UUID, indexUuid)
             .field(POLICY_ID, policyID)
-
         if (policySeqNo != null) builder.field(POLICY_SEQ_NO, policySeqNo)
         if (policyPrimaryTerm != null) builder.field(POLICY_PRIMARY_TERM, policyPrimaryTerm)
 
@@ -92,30 +122,17 @@ data class ManagedIndexMetaData(
         }
 
         val transitionToExists = transitionTo != null
-
         if (transitionToExists) {
             builder.field(TRANSITION_TO, transitionTo)
-        }
-
-        if (stateMetaData != null && !transitionToExists) {
-            builder.startObject(StateMetaData.STATE)
-            stateMetaData.toXContent(builder, params)
-            builder.endObject()
-        }
-
-        if (actionMetaData != null && !transitionToExists) {
-            builder.startObject(ActionMetaData.ACTION)
-            actionMetaData.toXContent(builder, params)
-            builder.endObject()
-        }
-
-        if (policyRetryInfo != null) {
-            builder.startObject(PolicyRetryInfoMetaData.RETRY_INFO)
-            policyRetryInfo.toXContent(builder, params)
-            builder.endObject()
+        } else {
+            builder.addObject(StateMetaData.STATE, stateMetaData, params)
+                .addObject(ActionMetaData.ACTION, actionMetaData, params)
+                .addObject(StepMetaData.STEP, stepMetaData, params)
+                .addObject(PolicyRetryInfoMetaData.RETRY_INFO, policyRetryInfo, params)
         }
 
         if (info != null) builder.field(INFO, info)
+
         return builder
     }
 
@@ -143,7 +160,8 @@ data class ManagedIndexMetaData(
     }
 
     companion object {
-        const val MANAGED_INDEX_METADATA = "managed_index_metadata"
+        const val NO_ID = ""
+        const val MANAGED_INDEX_METADATA_TYPE = "managed_index_metadata"
 
         const val NAME = "name"
         const val START_TIME = "start_time"
@@ -196,8 +214,16 @@ data class ManagedIndexMetaData(
             )
         }
 
-        @Suppress("ComplexMethod")
-        fun parse(xcp: XContentParser): ManagedIndexMetaData {
+        @Suppress("ComplexMethod", "LongMethod")
+        @JvmStatic
+        @JvmOverloads
+        @Throws(IOException::class)
+        fun parse(
+            xcp: XContentParser,
+            id: String = NO_ID,
+            seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
+            primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+        ): ManagedIndexMetaData {
             var index: String? = null
             var indexUuid: String? = null
             var policyID: String? = null
@@ -227,12 +253,23 @@ data class ManagedIndexMetaData(
                     POLICY_PRIMARY_TERM -> policyPrimaryTerm = if (xcp.currentToken() == Token.VALUE_NULL) null else xcp.longValue()
                     POLICY_COMPLETED -> policyCompleted = if (xcp.currentToken() == Token.VALUE_NULL) null else xcp.booleanValue()
                     ROLLED_OVER -> rolledOver = if (xcp.currentToken() == Token.VALUE_NULL) null else xcp.booleanValue()
-                    TRANSITION_TO -> transitionTo = xcp.text()
-                    StateMetaData.STATE -> state = StateMetaData.parse(xcp)
-                    ActionMetaData.ACTION -> action = ActionMetaData.parse(xcp)
-                    StepMetaData.STEP -> step = StepMetaData.parse(xcp)
-                    PolicyRetryInfoMetaData.RETRY_INFO -> retryInfo = PolicyRetryInfoMetaData.parse(xcp)
+                    TRANSITION_TO -> transitionTo = if (xcp.currentToken() == Token.VALUE_NULL) null else xcp.text()
+                    StateMetaData.STATE -> {
+                        // check null for invalid policy situation
+                        state = if (xcp.currentToken() == Token.VALUE_NULL) null else StateMetaData.parse(xcp)
+                    }
+                    ActionMetaData.ACTION -> {
+                        action = if (xcp.currentToken() == Token.VALUE_NULL) null else ActionMetaData.parse(xcp)
+                    }
+                    StepMetaData.STEP -> {
+                        step = if (xcp.currentToken() == Token.VALUE_NULL) null else StepMetaData.parse(xcp)
+                    }
+                    PolicyRetryInfoMetaData.RETRY_INFO -> {
+                        retryInfo = PolicyRetryInfoMetaData.parse(xcp)
+                    }
                     INFO -> info = xcp.map()
+                    // below line will break when getting metadata for explain or history
+                    // else -> throw IllegalArgumentException("Invalid field: [$fieldName] found in ManagedIndexMetaData.")
                 }
             }
 
@@ -249,8 +286,28 @@ data class ManagedIndexMetaData(
                 action,
                 step,
                 retryInfo,
-                info
+                info,
+                id,
+                seqNo,
+                primaryTerm
             )
+        }
+
+        @JvmStatic
+        @JvmOverloads
+        @Throws(IOException::class)
+        fun parseWithType(
+            xcp: XContentParser,
+            id: String = NO_ID,
+            seqNo: Long = SequenceNumbers.UNASSIGNED_SEQ_NO,
+            primaryTerm: Long = SequenceNumbers.UNASSIGNED_PRIMARY_TERM
+        ): ManagedIndexMetaData {
+            ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
+            ensureExpectedToken(Token.FIELD_NAME, xcp.nextToken(), xcp::getTokenLocation)
+            ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
+            val managedIndexMetaData = parse(xcp, id, seqNo, primaryTerm)
+            ensureExpectedToken(Token.END_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
+            return managedIndexMetaData
         }
 
         fun fromMap(map: Map<String, String?>): ManagedIndexMetaData {

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/model/managedindexmetadata/ActionMetaData.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/model/managedindexmetadata/ActionMetaData.kt
@@ -105,9 +105,9 @@ data class ActionMetaData(
         }
 
         fun fromManagedIndexMetaDataMap(map: Map<String, String?>): ActionMetaData? {
-            val stateJsonString = map[ACTION]
-            return if (stateJsonString != null) {
-                val inputStream = ByteArrayInputStream(stateJsonString.toByteArray(StandardCharsets.UTF_8))
+            val actionJsonString = map[ACTION]
+            return if (actionJsonString != null) {
+                val inputStream = ByteArrayInputStream(actionJsonString.toByteArray(StandardCharsets.UTF_8))
                 val parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, inputStream)
                 parser.nextToken()
                 parse(parser)

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/model/managedindexmetadata/StepMetaData.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/model/managedindexmetadata/StepMetaData.kt
@@ -48,11 +48,12 @@ data class StepMetaData(
     }
 
     override fun toXContent(builder: XContentBuilder, params: ToXContent.Params): XContentBuilder {
-        return builder.startObject(STEP)
+        builder
             .field(NAME, name)
             .field(START_TIME, startTime)
             .field(STEP_STATUS, stepStatus.toString())
-            .endObject()
+
+        return builder
     }
 
     fun getMapValueString(): String {
@@ -76,9 +77,9 @@ data class StepMetaData(
         }
 
         fun fromManagedIndexMetaDataMap(map: Map<String, String?>): StepMetaData? {
-            val stateJsonString = map[STEP]
-            return if (stateJsonString != null) {
-                val inputStream = ByteArrayInputStream(stateJsonString.toByteArray(StandardCharsets.UTF_8))
+            val stepJsonString = map[STEP]
+            return if (stepJsonString != null) {
+                val inputStream = ByteArrayInputStream(stepJsonString.toByteArray(StandardCharsets.UTF_8))
                 val parser = XContentType.JSON.xContent().createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, inputStream)
                 parser.nextToken()
                 parse(parser)

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/resthandler/RestExplainAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/resthandler/RestExplainAction.kt
@@ -45,7 +45,6 @@ class RestExplainAction : BaseRestHandler() {
         return "ism_explain_action"
     }
 
-    @Suppress("SpreadOperator") // There is no way around dealing with java vararg without spread operator.
     override fun prepareRequest(request: RestRequest, client: NodeClient): RestChannelConsumer {
         val indices: Array<String>? = Strings.splitStringByCommaToArray(request.param("index"))
         if (indices == null || indices.isEmpty()) {
@@ -53,7 +52,7 @@ class RestExplainAction : BaseRestHandler() {
         }
 
         val explainRequest = ExplainRequest(indices.toList(), request.paramAsBoolean("local", false),
-                request.paramAsTime("master_timeout", MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT))
+            request.paramAsTime("master_timeout", MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT))
 
         return RestChannelConsumer { channel ->
             client.execute(ExplainAction.INSTANCE, explainRequest, RestToXContentListener(channel))

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexAction.kt
@@ -58,7 +58,7 @@ class RestRetryFailedManagedIndexAction : BaseRestHandler() {
         }
 
         val retryFailedRequest = RetryFailedManagedIndexRequest(indices.toList(), body["state"] as String?,
-                request.paramAsTime("master_timeout", DEFAULT_MASTER_NODE_TIMEOUT))
+            request.paramAsTime("master_timeout", DEFAULT_MASTER_NODE_TIMEOUT))
 
         return RestChannelConsumer { channel ->
             client.execute(RetryFailedManagedIndexAction.INSTANCE, retryFailedRequest, RestToXContentListener(channel))

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt
@@ -24,7 +24,7 @@ import java.util.function.Function
 class ManagedIndexSettings {
     companion object {
         const val DEFAULT_ISM_ENABLED = true
-        const val DEFAULT_JOB_INTERVAL = 5
+        const val DEFAULT_JOB_INTERVAL = 1
         private val ALLOW_LIST_ALL = ActionConfig.ActionType.values().toList().map { it.type }
         val ALLOW_LIST_NONE = emptyList<String>()
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/TransportChangePolicyAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/transport/action/changepolicy/TransportChangePolicyAction.kt
@@ -277,7 +277,8 @@ class TransportChangePolicyAction @Inject constructor(
             )
             val excludes = emptyArray<String>()
             val fetchSourceContext = FetchSourceContext(true, includes, excludes)
-            managedIndexUuids.forEach { request.add(MultiGetRequest.Item(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, it).fetchSourceContext(fetchSourceContext)) }
+            managedIndexUuids.forEach { request.add(MultiGetRequest.Item(
+                IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, it).fetchSourceContext(fetchSourceContext).routing(it)) }
             return request
         }
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
@@ -59,7 +59,7 @@ class TransportExplainAction @Inject constructor(
         lateinit var response: GetResponse
 
         private val indexNames = mutableListOf<String>()
-        private val indexMetadataUuids = mutableListOf<String>()
+        private val indexUuids = mutableListOf<String>()
         private val indexPolicyIds = mutableListOf<String?>()
 
         @Suppress("SpreadOperator") // There is no way around dealing with java vararg without spread operator.
@@ -87,12 +87,12 @@ class TransportExplainAction @Inject constructor(
         private fun onClusterStateResponse(response: ClusterStateResponse) {
             for (indexMetadataEntry in response.state.metadata.indices) {
                 indexNames.add(indexMetadataEntry.key)
-                indexMetadataUuids.add(indexMetadataEntry.value.indexUUID + "metadata")
+                indexUuids.add(indexMetadataEntry.value.indexUUID)
                 indexPolicyIds.add(indexMetadataEntry.value.getPolicyID())
             }
 
             val mgetRequest = MultiGetRequest()
-            indexMetadataUuids.forEach { mgetRequest.add(MultiGetRequest.Item(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, it)) }
+            indexUuids.forEach { mgetRequest.add(MultiGetRequest.Item(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, it + "metadata").routing(it)) }
             client.multiGet(mgetRequest, object : ActionListener<MultiGetResponse> {
                 override fun onResponse(response: MultiGetResponse) {
                     processResponse(response)

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/transport/action/explain/TransportExplainAction.kt
@@ -108,6 +108,7 @@ class TransportExplainAction @Inject constructor(
             val indexMetadatas = mutableListOf<ManagedIndexMetaData?>()
 
             response.responses.forEach {
+                log.info("explain response: ${it.id}")
                 if (it.response != null) {
                     indexMetadatas.add(getMetadata(it.response))
                 } else {
@@ -119,6 +120,7 @@ class TransportExplainAction @Inject constructor(
         }
 
         private fun getMetadata(response: GetResponse): ManagedIndexMetaData? {
+            log.info("transfer multiget response toXContent for ${response.sourceAsMap}")
             if (response.sourceAsBytesRef == null) return null
 
             val xcp = XContentHelper.createParser(

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/transport/action/retryfailedmanagedindex/TransportRetryFailedManagedIndexAction.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/transport/action/retryfailedmanagedindex/TransportRetryFailedManagedIndexAction.kt
@@ -172,7 +172,6 @@ class TransportRetryFailedManagedIndexAction @Inject constructor(
                 }
 
                 val updateMetadataRequests = listOfIndexToMetadata.map { (index, metadata) ->
-                    log.info("try to save metadata [$metadata] in retry")
                     val builder = metadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS, true)
                     UpdateRequest(IndexManagementPlugin.INDEX_MANAGEMENT_INDEX, index.uuid + "metadata").doc(builder)
                 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -43,6 +43,7 @@ import org.elasticsearch.action.DocWriteRequest
 import org.elasticsearch.action.delete.DeleteRequest
 import org.elasticsearch.action.index.IndexRequest
 import org.elasticsearch.action.search.SearchRequest
+import org.elasticsearch.action.support.WriteRequest
 import org.elasticsearch.action.update.UpdateRequest
 import org.elasticsearch.client.Client
 import org.elasticsearch.cluster.service.ClusterService
@@ -98,6 +99,7 @@ fun managedIndexMetadataIndexRequest(managedIndexMetadata: ManagedIndexMetaData)
             .setIfPrimaryTerm(managedIndexMetadata.primaryTerm)
             .setIfSeqNo(managedIndexMetadata.seqNo)
             .routing(managedIndexMetadata.indexUuid)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.WAIT_UNTIL)
             .source(managedIndexMetadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS, true))
 }
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -50,6 +50,7 @@ import org.elasticsearch.common.unit.ByteSizeValue
 import org.elasticsearch.common.unit.TimeValue
 import org.elasticsearch.common.xcontent.ToXContent
 import org.elasticsearch.common.xcontent.XContentFactory
+import org.elasticsearch.index.Index
 import org.elasticsearch.index.query.BoolQueryBuilder
 import org.elasticsearch.index.query.QueryBuilders
 import org.elasticsearch.script.ScriptService
@@ -76,6 +77,7 @@ fun managedIndexConfigIndexRequest(index: String, uuid: String, policyID: String
     return IndexRequest(INDEX_MANAGEMENT_INDEX)
             .id(uuid)
             .create(true)
+            .routing(managedIndexConfig.indexUuid)
             .source(managedIndexConfig.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
 }
 
@@ -84,7 +86,19 @@ fun managedIndexConfigIndexRequest(managedIndexConfig: ManagedIndexConfig): Inde
             .id(managedIndexConfig.indexUuid)
             .setIfPrimaryTerm(managedIndexConfig.primaryTerm)
             .setIfSeqNo(managedIndexConfig.seqNo)
+            .routing(managedIndexConfig.indexUuid)
             .source(managedIndexConfig.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
+}
+
+fun managedIndexMetadataIndexRequest(managedIndexMetadata: ManagedIndexMetaData): IndexRequest {
+    // routing set using managed index's uuid
+    // so that metadata doc and managed-index doc are in the same place
+    return IndexRequest(INDEX_MANAGEMENT_INDEX)
+            .id(managedIndexMetadata.indexUuid + "metadata")
+            .setIfPrimaryTerm(managedIndexMetadata.primaryTerm)
+            .setIfSeqNo(managedIndexMetadata.seqNo)
+            .routing(managedIndexMetadata.indexUuid)
+            .source(managedIndexMetadata.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS, true))
 }
 
 private fun updateEnabledField(uuid: String, enabled: Boolean, enabledTime: Long?): UpdateRequest {
@@ -109,6 +123,10 @@ fun updateEnableManagedIndexRequest(uuid: String): UpdateRequest {
 
 fun deleteManagedIndexRequest(uuid: String): DeleteRequest {
     return DeleteRequest(INDEX_MANAGEMENT_INDEX, uuid)
+}
+
+fun deleteManagedIndexMetadataRequest(uuid: String): DeleteRequest {
+    return DeleteRequest(INDEX_MANAGEMENT_INDEX, uuid + "metadata")
 }
 
 fun updateManagedIndexRequest(sweptManagedIndexConfig: SweptManagedIndexConfig): UpdateRequest {
@@ -158,6 +176,15 @@ fun getDeleteManagedIndexRequests(
     return currentManagedIndexConfigs.filter { (uuid) ->
         !clusterStateManagedIndexConfigs.containsKey(uuid)
     }.map { deleteManagedIndexRequest(it.value.uuid) }
+}
+
+fun getDeleteManagedIndices(
+    clusterStateManagedIndexConfigs: Map<String, ClusterStateManagedIndexConfig>,
+    currentManagedIndexConfigs: Map<String, SweptManagedIndexConfig>
+): List<Index> {
+    return currentManagedIndexConfigs.filter { (uuid) ->
+        !clusterStateManagedIndexConfigs.containsKey(uuid)
+    }.map { Index(it.value.index, it.value.uuid) }
 }
 
 fun getSweptManagedIndexSearchRequest(): SearchRequest {
@@ -302,6 +329,7 @@ fun Action.getUpdatedActionMetaData(managedIndexMetaData: ManagedIndexMetaData, 
     val actionMetaData = managedIndexMetaData.actionMetaData
 
     return when {
+        // start a new action
         stateMetaData?.name != state.name ->
             ActionMetaData(this.type.type, Instant.now().toEpochMilli(), this.config.actionIndex, false, 0, 0, null)
         actionMetaData?.index != this.config.actionIndex ->

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/util/ManagedIndexUtils.kt
@@ -86,7 +86,7 @@ fun managedIndexConfigIndexRequest(managedIndexConfig: ManagedIndexConfig): Inde
             .id(managedIndexConfig.indexUuid)
             .setIfPrimaryTerm(managedIndexConfig.primaryTerm)
             .setIfSeqNo(managedIndexConfig.seqNo)
-            .routing(managedIndexConfig.indexUuid)
+            .routing(managedIndexConfig.indexUuid) // we want job doc and its metadata doc be routed to same shard
             .source(managedIndexConfig.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS))
 }
 

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -535,7 +535,7 @@
               "type": "long"
             },
             "step_status": {
-              "type": "text"
+              "type": "keyword"
             }
           }
         },

--- a/src/main/resources/mappings/opendistro-ism-config.json
+++ b/src/main/resources/mappings/opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 4
+    "schema_version": 5
   },
   "dynamic": "strict",
   "properties": {
@@ -425,6 +425,133 @@
               }
             }
           }
+        }
+      }
+    },
+    "managed_index_metadata": {
+      "properties": {
+        "index": {
+          "type" : "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "index_uuid": {
+          "type" : "keyword"
+        },
+        "policy_id": {
+          "type" : "keyword"
+        },
+        "policy_seq_no": {
+          "type": "long"
+        },
+        "policy_primary_term": {
+          "type": "long"
+        },
+        "policy_completed": {
+          "type": "boolean"
+        },
+        "rolled_over": {
+          "type": "boolean"
+        },
+        "transition_to": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "state": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "start_time": {
+              "type": "long"
+            }
+          }
+        },
+        "action": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "start_time": {
+              "type": "long"
+            },
+            "index": {
+              "type": "integer"
+            },
+            "failed": {
+              "type": "boolean"
+            },
+            "consumed_retries": {
+              "type": "integer"
+            },
+            "last_retry_time": {
+              "type": "long"
+            },
+            "action_properties": {
+              "properties": {
+                "max_num_segments": {
+                  "type": "integer"
+                },
+                "snapshot_name": {
+                  "type": "text"
+                }
+              }
+            }
+          }
+        },
+        "step": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "start_time": {
+              "type": "long"
+            },
+            "step_status": {
+              "type": "text"
+            }
+          }
+        },
+        "retry_info": {
+          "properties": {
+            "failed": {
+              "type": "boolean"
+            },
+            "consumed_retries": {
+              "type": "integer"
+            }
+          }
+        },
+        "info": {
+          "type": "object",
+          "enabled": false
         }
       }
     }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/IndexManagementIndicesIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/IndexManagementIndicesIT.kt
@@ -50,17 +50,17 @@ class IndexManagementIndicesIT : IndexStateManagementRestTestCase() {
 
     fun `test create index management`() {
         val policy = randomPolicy()
-        val policyId = ESTestCase.randomAlphaOfLength(10)
+        val policyId = randomAlphaOfLength(10)
         client().makeRequest("PUT", "$POLICY_BASE_URI/$policyId", emptyMap(), policy.toHttpEntity())
         assertIndexExists(INDEX_MANAGEMENT_INDEX)
-        verifyIndexSchemaVersion(INDEX_MANAGEMENT_INDEX, 4)
+        verifyIndexSchemaVersion(INDEX_MANAGEMENT_INDEX, 5)
     }
 
     fun `test update management index mapping with new schema version`() {
         assertIndexDoesNotExist(INDEX_MANAGEMENT_INDEX)
 
         val mapping = indexManagementMappings.trim().trimStart('{').trimEnd('}')
-            .replace("\"schema_version\": 4", "\"schema_version\": 0")
+            .replace("\"schema_version\": 5", "\"schema_version\": 0")
 
         createIndex(INDEX_MANAGEMENT_INDEX, Settings.builder().put("index.hidden", true).build(), mapping)
         assertIndexExists(INDEX_MANAGEMENT_INDEX)
@@ -71,7 +71,7 @@ class IndexManagementIndicesIT : IndexStateManagementRestTestCase() {
         client().makeRequest("PUT", "$POLICY_BASE_URI/$policyId", emptyMap(), policy.toHttpEntity())
 
         assertIndexExists(INDEX_MANAGEMENT_INDEX)
-        verifyIndexSchemaVersion(INDEX_MANAGEMENT_INDEX, 4)
+        verifyIndexSchemaVersion(INDEX_MANAGEMENT_INDEX, 5)
     }
 
     fun `test update management index history mappings with new schema version`() {
@@ -115,8 +115,7 @@ class IndexManagementIndicesIT : IndexStateManagementRestTestCase() {
         assertEquals("Policy id does not match", policy.id, managedIndexConfig.policyID)
 
         val mapping = "{" + indexManagementMappings.trimStart('{').trimEnd('}')
-            .replace("\"schema_version\": 4", "\"schema_version\": 0")
-
+            .replace("\"schema_version\": 5", "\"schema_version\": 0")
         val entity = StringEntity(mapping, ContentType.APPLICATION_JSON)
         client().makeRequest(RestRequest.Method.PUT.toString(),
             "/$INDEX_MANAGEMENT_INDEX/_mapping", emptyMap(), entity)
@@ -129,7 +128,7 @@ class IndexManagementIndicesIT : IndexStateManagementRestTestCase() {
             RestRequest.Method.POST.toString(),
             "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/$index", emptyMap(), changePolicy.toHttpEntity())
 
-        verifyIndexSchemaVersion(INDEX_MANAGEMENT_INDEX, 4)
+        verifyIndexSchemaVersion(INDEX_MANAGEMENT_INDEX, 5)
 
         assertAffectedIndicesResponseIsEqual(mapOf(FAILURES to false, FAILED_INDICES to emptyList<Any>(), UPDATED_INDICES to 1), response.asMap())
 

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementITTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementITTestCase.kt
@@ -1,0 +1,276 @@
+package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement
+
+import com.amazon.opendistroforelasticsearch.indexmanagement.IndexManagementPlugin
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.ManagedIndexConfig
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.Policy
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.PolicyRetryInfoMetaData
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StateMetaData
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.resthandler.RestExplainAction
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import com.amazon.opendistroforelasticsearch.jobscheduler.spi.schedule.IntervalSchedule
+import org.apache.http.entity.ContentType
+import org.apache.http.entity.StringEntity
+import org.elasticsearch.ElasticsearchParseException
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest
+import org.elasticsearch.action.search.SearchResponse
+import org.elasticsearch.client.Request
+import org.elasticsearch.client.Response
+import org.elasticsearch.cluster.metadata.IndexMetadata
+import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand
+import org.elasticsearch.common.Strings
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.xcontent.DeprecationHandler
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.common.xcontent.XContentHelper
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.common.xcontent.XContentParserUtils
+import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.common.xcontent.json.JsonXContent
+import org.elasticsearch.plugins.Plugin
+import org.elasticsearch.rest.RestRequest
+import org.elasticsearch.rest.RestStatus
+import org.elasticsearch.test.ESIntegTestCase
+import org.elasticsearch.test.rest.ESRestTestCase.entityAsMap
+import java.io.IOException
+import java.time.Duration
+import java.time.Instant
+
+abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
+
+    protected val isMixedNodeRegressionTest = System.getProperty("cluster.mixed", "false")!!.toBoolean()
+
+    var metadataToClusterState = ManagedIndexMetaData(
+        index = "",
+        indexUuid = "",
+        policyID = "",
+        policySeqNo = 0,
+        policyPrimaryTerm = 1,
+        policyCompleted = false,
+        rolledOver = false,
+        transitionTo = null,
+        stateMetaData = StateMetaData("ReplicaCountState", 1234),
+        actionMetaData = null,
+        stepMetaData = null,
+        policyRetryInfo = PolicyRetryInfoMetaData(false, 0),
+        info = mapOf("message" to "Happy moving")
+    )
+
+    override fun nodePlugins(): Collection<Class<out Plugin>> {
+        return listOf(IndexManagementPlugin::class.java)
+    }
+
+    override fun transportClientPlugins(): Collection<Class<out Plugin>> {
+        return listOf(IndexManagementPlugin::class.java)
+    }
+
+    protected fun getIndexMetadata(indexName: String): IndexMetadata {
+        return client().admin().cluster().prepareState()
+                .setIndices(indexName)
+                .setMetadata(true).get()
+                .state.metadata.indices[indexName]
+    }
+
+    // reuse utility fun from RestTestCase
+    fun createPolicy(
+        policy: Policy,
+        policyId: String = randomAlphaOfLength(10),
+        refresh: Boolean = true
+    ): Policy {
+        val response = createPolicyJson(policy.toJsonString(), policyId, refresh)
+
+        val policyJson = JsonXContent.jsonXContent
+                .createParser(
+                        NamedXContentRegistry.EMPTY,
+                        LoggingDeprecationHandler.INSTANCE,
+                        response.entity.content
+                ).map()
+        val createdId = policyJson["_id"] as String
+        assertEquals("policy ids are not the same", policyId, createdId)
+        return policy.copy(
+                id = createdId,
+                seqNo = (policyJson["_seq_no"] as Int).toLong(),
+                primaryTerm = (policyJson["_primary_term"] as Int).toLong()
+        )
+    }
+
+    protected fun createPolicyJson(
+        policyString: String,
+        policyId: String,
+        refresh: Boolean = true
+    ): Response {
+        val response = getRestClient()
+                .makeRequest(
+                        "PUT",
+                        "${IndexManagementPlugin.POLICY_BASE_URI}/$policyId?refresh=$refresh",
+                        emptyMap(),
+                        StringEntity(policyString, ContentType.APPLICATION_JSON)
+                )
+        assertEquals("Unable to create a new policy", RestStatus.CREATED, response.restStatus())
+        return response
+    }
+
+    protected fun Response.restStatus(): RestStatus = RestStatus.fromCode(this.statusLine.statusCode)
+
+    protected fun addPolicyToIndex(
+        index: String,
+        policyID: String
+    ) {
+        val settings = Settings.builder().put(ManagedIndexSettings.POLICY_ID.key, policyID).build()
+        val request = Request("PUT", "/$index/_settings")
+        request.setJsonEntity(Strings.toString(settings))
+        getRestClient().performRequest(request)
+    }
+
+    protected fun getExistingManagedIndexConfig(index: String): ManagedIndexConfig {
+        return waitFor {
+            val config = getManagedIndexConfig(index)
+            assertNotNull("ManagedIndexConfig is null", config)
+            config!!
+        }
+    }
+
+    protected fun getManagedIndexConfig(index: String): ManagedIndexConfig? {
+        val request = """
+            {
+                "seq_no_primary_term": true,
+                "query": {
+                    "term": {
+                        "${ManagedIndexConfig.MANAGED_INDEX_TYPE}.${ManagedIndexConfig.INDEX_FIELD}": "$index"
+                    }
+                }
+            }
+        """.trimIndent()
+        val response = getRestClient().makeRequest("POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_search", emptyMap(),
+                StringEntity(request, ContentType.APPLICATION_JSON))
+        assertEquals("Request failed", RestStatus.OK, response.restStatus())
+        val searchResponse = SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, response.entity.content))
+        assertTrue("Found more than one managed index config", searchResponse.hits.hits.size < 2)
+        val hit = searchResponse.hits.hits.firstOrNull()
+        return hit?.run {
+            val xcp = createParser(JsonXContent.jsonXContent, this.sourceRef)
+            ManagedIndexConfig.parseWithType(xcp, id, seqNo, primaryTerm)
+        }
+    }
+
+    protected fun seeConfigIndex() {
+        val response = getRestClient().makeRequest("GET", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_search")
+        val searchResponse = SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, response.entity.content))
+        val hits = searchResponse.hits.hits
+        hits.forEach { logger.info("what is inside config index? $it") }
+    }
+
+    protected fun updateManagedIndexConfigStartTime(update: ManagedIndexConfig, desiredStartTimeMillis: Long? = null) {
+        val intervalSchedule = (update.jobSchedule as IntervalSchedule)
+        val millis = Duration.of(intervalSchedule.interval.toLong(), intervalSchedule.unit).minusSeconds(2).toMillis()
+        val startTimeMillis = desiredStartTimeMillis ?: Instant.now().toEpochMilli() - millis
+        val response = getRestClient().makeRequest("POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}",
+                StringEntity(
+                        "{\"doc\":{\"managed_index\":{\"schedule\":{\"interval\":{\"start_time\":" +
+                                "\"$startTimeMillis\"}}}}}",
+                        ContentType.APPLICATION_JSON
+                ))
+
+        assertEquals("Request failed", RestStatus.OK, response.restStatus())
+    }
+
+    protected fun updateManagedIndexConfigPolicy(update: ManagedIndexConfig, policy: Policy) {
+        val policyJsonString = policy.toJsonString()
+        logger.info("policy string: $policyJsonString")
+        var response = getRestClient().makeRequest("POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}",
+                StringEntity(
+                        "{\"doc\":{\"managed_index\": $policyJsonString }}",
+                        ContentType.APPLICATION_JSON
+                ))
+
+        assertEquals("Request failed", RestStatus.OK, response.restStatus())
+
+        response = getRestClient().makeRequest("POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}",
+                StringEntity(
+                        "{\"doc\":{\"managed_index\": {\"policy_seq_no\": \"0\", \"policy_primary_term\": \"1\"} }}",
+                        ContentType.APPLICATION_JSON
+                ))
+
+        assertEquals("Request failed", RestStatus.OK, response.restStatus())
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    protected fun getNumberOfReplicasSetting(indexName: String): Int {
+        val indexSettings = getIndexSettings(indexName) as Map<String, Map<String, Map<String, Any?>>>
+        return (indexSettings[indexName]!!["settings"]!!["index.number_of_replicas"] as String).toInt()
+    }
+
+    @Throws(IOException::class)
+    protected open fun getIndexSettings(index: String): Map<String?, Any?>? {
+        val request = Request("GET", "/$index/_settings")
+        request.addParameter("flat_settings", "true")
+        val response = getRestClient().performRequest(request)
+        response.entity.content.use { `is` -> return XContentHelper.convertToMap(XContentType.JSON.xContent(), `is`, true) }
+    }
+
+    protected fun getExplainManagedIndexMetaData(indexName: String): ManagedIndexMetaData {
+        if (indexName.contains("*") || indexName.contains(",")) {
+            throw IllegalArgumentException("This method is only for a single concrete index")
+        }
+
+        val response = getRestClient().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$indexName")
+        assertEquals("Unexpected RestStatus", RestStatus.OK, response.restStatus())
+
+        lateinit var metadata: ManagedIndexMetaData
+        val xcp = createParser(XContentType.JSON.xContent(), response.entity.content)
+        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
+        while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
+            xcp.currentName()
+            xcp.nextToken()
+
+            metadata = ManagedIndexMetaData.parse(xcp)
+        }
+        return metadata
+    }
+
+    protected fun assertIndexExists(index: String) {
+        val response = getRestClient().makeRequest("HEAD", index)
+        assertEquals("Index $index does not exist.", RestStatus.OK, response.restStatus())
+    }
+
+    fun getShardSegmentStats(index: String): Map<String, Any> {
+        val response = getRestClient().makeRequest("GET", "/$index/_stats/segments?level=shards")
+
+        assertEquals("Stats request failed", RestStatus.OK, response.restStatus())
+
+        return response.asMap()
+    }
+
+    fun catIndexShard(index: String): List<Any> {
+        val response = getRestClient().makeRequest("GET", "_cat/shards/$index?format=json")
+
+        assertEquals("Stats request failed", RestStatus.OK, response.restStatus())
+
+        try {
+            return JsonXContent.jsonXContent
+                    .createParser(NamedXContentRegistry.EMPTY,
+                            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                            response.entity.content)
+                    .use { parser -> parser.list() }
+        } catch (e: IOException) {
+            throw ElasticsearchParseException("Failed to parse content to list", e)
+        }
+    }
+
+    fun Response.asMap(): Map<String, Any> = entityAsMap(this)
+
+    fun rerouteShard(configIndexName: String, fromNode: String, toNode: String) {
+        logger.info("Reallocating Shard. From Node: $fromNode To Node: $toNode ")
+        val moveCommand = MoveAllocationCommand(configIndexName, 0, fromNode, toNode)
+        val rerouteResponse = client().admin().cluster()
+                .reroute(ClusterRerouteRequest().add(moveCommand)).actionGet()
+        logger.info("reroute success? ${rerouteResponse.isAcknowledged}")
+    }
+
+    fun updateIndexSettings(index: String, settings: Settings) {
+        val request = Request("PUT", "/$index/_settings")
+        request.setJsonEntity(Strings.toString(settings))
+        getRestClient().performRequest(request)
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementITTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementITTestCase.kt
@@ -67,9 +67,9 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
 
     protected fun getIndexMetadata(indexName: String): IndexMetadata {
         return client().admin().cluster().prepareState()
-                .setIndices(indexName)
-                .setMetadata(true).get()
-                .state.metadata.indices[indexName]
+            .setIndices(indexName)
+            .setMetadata(true).get()
+            .state.metadata.indices[indexName]
     }
 
     // reuse utility fun from RestTestCase
@@ -81,17 +81,17 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
         val response = createPolicyJson(policy.toJsonString(), policyId, refresh)
 
         val policyJson = JsonXContent.jsonXContent
-                .createParser(
-                        NamedXContentRegistry.EMPTY,
-                        LoggingDeprecationHandler.INSTANCE,
-                        response.entity.content
-                ).map()
+            .createParser(
+                NamedXContentRegistry.EMPTY,
+                LoggingDeprecationHandler.INSTANCE,
+                response.entity.content
+            ).map()
         val createdId = policyJson["_id"] as String
         assertEquals("policy ids are not the same", policyId, createdId)
         return policy.copy(
-                id = createdId,
-                seqNo = (policyJson["_seq_no"] as Int).toLong(),
-                primaryTerm = (policyJson["_primary_term"] as Int).toLong()
+            id = createdId,
+            seqNo = (policyJson["_seq_no"] as Int).toLong(),
+            primaryTerm = (policyJson["_primary_term"] as Int).toLong()
         )
     }
 
@@ -101,12 +101,12 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
         refresh: Boolean = true
     ): Response {
         val response = getRestClient()
-                .makeRequest(
-                        "PUT",
-                        "${IndexManagementPlugin.POLICY_BASE_URI}/$policyId?refresh=$refresh",
-                        emptyMap(),
-                        StringEntity(policyString, ContentType.APPLICATION_JSON)
-                )
+            .makeRequest(
+                "PUT",
+                "${IndexManagementPlugin.POLICY_BASE_URI}/$policyId?refresh=$refresh",
+                emptyMap(),
+                StringEntity(policyString, ContentType.APPLICATION_JSON)
+            )
         assertEquals("Unable to create a new policy", RestStatus.CREATED, response.restStatus())
         return response
     }
@@ -142,10 +142,13 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
                 }
             }
         """.trimIndent()
-        val response = getRestClient().makeRequest("POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_search", emptyMap(),
-                StringEntity(request, ContentType.APPLICATION_JSON))
+        val response = getRestClient().makeRequest(
+            "POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_search", emptyMap(),
+            StringEntity(request, ContentType.APPLICATION_JSON)
+        )
         assertEquals("Request failed", RestStatus.OK, response.restStatus())
-        val searchResponse = SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, response.entity.content))
+        val searchResponse =
+            SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, response.entity.content))
         assertTrue("Found more than one managed index config", searchResponse.hits.hits.size < 2)
         val hit = searchResponse.hits.hits.firstOrNull()
         return hit?.run {
@@ -156,7 +159,8 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
 
     protected fun seeConfigIndex() {
         val response = getRestClient().makeRequest("GET", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_search")
-        val searchResponse = SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, response.entity.content))
+        val searchResponse =
+            SearchResponse.fromXContent(createParser(JsonXContent.jsonXContent, response.entity.content))
         val hits = searchResponse.hits.hits
         hits.forEach { logger.info("what is inside config index? $it") }
     }
@@ -165,12 +169,14 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
         val intervalSchedule = (update.jobSchedule as IntervalSchedule)
         val millis = Duration.of(intervalSchedule.interval.toLong(), intervalSchedule.unit).minusSeconds(2).toMillis()
         val startTimeMillis = desiredStartTimeMillis ?: Instant.now().toEpochMilli() - millis
-        val response = getRestClient().makeRequest("POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}",
-                StringEntity(
-                        "{\"doc\":{\"managed_index\":{\"schedule\":{\"interval\":{\"start_time\":" +
-                                "\"$startTimeMillis\"}}}}}",
-                        ContentType.APPLICATION_JSON
-                ))
+        val response = getRestClient().makeRequest(
+            "POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}",
+            StringEntity(
+                "{\"doc\":{\"managed_index\":{\"schedule\":{\"interval\":{\"start_time\":" +
+                    "\"$startTimeMillis\"}}}}}",
+                ContentType.APPLICATION_JSON
+            )
+        )
 
         assertEquals("Request failed", RestStatus.OK, response.restStatus())
     }
@@ -178,19 +184,23 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
     protected fun updateManagedIndexConfigPolicy(update: ManagedIndexConfig, policy: Policy) {
         val policyJsonString = policy.toJsonString()
         logger.info("policy string: $policyJsonString")
-        var response = getRestClient().makeRequest("POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}",
-                StringEntity(
-                        "{\"doc\":{\"managed_index\": $policyJsonString }}",
-                        ContentType.APPLICATION_JSON
-                ))
+        var response = getRestClient().makeRequest(
+            "POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}",
+            StringEntity(
+                "{\"doc\":{\"managed_index\": $policyJsonString }}",
+                ContentType.APPLICATION_JSON
+            )
+        )
 
         assertEquals("Request failed", RestStatus.OK, response.restStatus())
 
-        response = getRestClient().makeRequest("POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}",
-                StringEntity(
-                        "{\"doc\":{\"managed_index\": {\"policy_seq_no\": \"0\", \"policy_primary_term\": \"1\"} }}",
-                        ContentType.APPLICATION_JSON
-                ))
+        response = getRestClient().makeRequest(
+            "POST", "${IndexManagementPlugin.INDEX_MANAGEMENT_INDEX}/_update/${update.id}",
+            StringEntity(
+                "{\"doc\":{\"managed_index\": {\"policy_seq_no\": \"0\", \"policy_primary_term\": \"1\"} }}",
+                ContentType.APPLICATION_JSON
+            )
+        )
 
         assertEquals("Request failed", RestStatus.OK, response.restStatus())
     }
@@ -206,7 +216,13 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
         val request = Request("GET", "/$index/_settings")
         request.addParameter("flat_settings", "true")
         val response = getRestClient().performRequest(request)
-        response.entity.content.use { `is` -> return XContentHelper.convertToMap(XContentType.JSON.xContent(), `is`, true) }
+        response.entity.content.use { `is` ->
+            return XContentHelper.convertToMap(
+                XContentType.JSON.xContent(),
+                `is`,
+                true
+            )
+        }
     }
 
     protected fun getExplainManagedIndexMetaData(indexName: String): ManagedIndexMetaData {
@@ -214,12 +230,19 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
             throw IllegalArgumentException("This method is only for a single concrete index")
         }
 
-        val response = getRestClient().makeRequest(RestRequest.Method.GET.toString(), "${RestExplainAction.EXPLAIN_BASE_URI}/$indexName")
+        val response = getRestClient().makeRequest(
+            RestRequest.Method.GET.toString(),
+            "${RestExplainAction.EXPLAIN_BASE_URI}/$indexName"
+        )
         assertEquals("Unexpected RestStatus", RestStatus.OK, response.restStatus())
 
         lateinit var metadata: ManagedIndexMetaData
         val xcp = createParser(XContentType.JSON.xContent(), response.entity.content)
-        XContentParserUtils.ensureExpectedToken(XContentParser.Token.START_OBJECT, xcp.nextToken(), xcp::getTokenLocation)
+        XContentParserUtils.ensureExpectedToken(
+            XContentParser.Token.START_OBJECT,
+            xcp.nextToken(),
+            xcp::getTokenLocation
+        )
         while (xcp.nextToken() != XContentParser.Token.END_OBJECT) {
             xcp.currentName()
             xcp.nextToken()
@@ -249,10 +272,12 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
 
         try {
             return JsonXContent.jsonXContent
-                    .createParser(NamedXContentRegistry.EMPTY,
-                            DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
-                            response.entity.content)
-                    .use { parser -> parser.list() }
+                .createParser(
+                    NamedXContentRegistry.EMPTY,
+                    DeprecationHandler.THROW_UNSUPPORTED_OPERATION,
+                    response.entity.content
+                )
+                .use { parser -> parser.list() }
         } catch (e: IOException) {
             throw ElasticsearchParseException("Failed to parse content to list", e)
         }
@@ -264,7 +289,7 @@ abstract class IndexStateManagementITTestCase : ESIntegTestCase() {
         logger.info("Reallocating Shard. From Node: $fromNode To Node: $toNode ")
         val moveCommand = MoveAllocationCommand(configIndexName, 0, fromNode, toNode)
         val rerouteResponse = client().admin().cluster()
-                .reroute(ClusterRerouteRequest().add(moveCommand)).actionGet()
+            .reroute(ClusterRerouteRequest().add(moveCommand)).actionGet()
         logger.info("reroute success? ${rerouteResponse.isAcknowledged}")
     }
 

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementITTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementITTestCase.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement
 
 import com.amazon.opendistroforelasticsearch.indexmanagement.IndexManagementPlugin

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/IndexStateManagementRestTestCase.kt
@@ -72,7 +72,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
-import java.util.*
+import java.util.Locale
 import javax.management.MBeanServerInvocationHandler
 import javax.management.ObjectName
 import javax.management.remote.JMXConnectorFactory

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/MetadataRegressionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/MetadataRegressionIT.kt
@@ -1,0 +1,200 @@
+package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement
+
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.Policy
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.State
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.action.ReplicaCountActionConfig
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataAction
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataRequest
+import org.elasticsearch.action.support.master.AcknowledgedResponse
+import org.elasticsearch.cluster.metadata.IndexMetadata
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.index.Index
+import org.junit.Assume
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+
+class MetadataRegressionIT : IndexStateManagementITTestCase() {
+
+    private val testIndexName = javaClass.simpleName.toLowerCase(Locale.ROOT)
+
+    fun `test still have metadata saved in cluster state`() {
+        /**
+         *  create index, manually save metadata into this index's cluster state;
+         *  configure and start a job, check if metadata moved from cluster state to config index;
+         */
+
+        val indexName = "${testIndexName}_index_1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+        val actionConfig = ReplicaCountActionConfig(10, 0)
+        val states = listOf(State(name = "ReplicaCountState", actions = listOf(actionConfig), transitions = listOf()))
+        val policy = Policy(
+                id = policyID,
+                description = "$testIndexName description",
+                schemaVersion = 1L,
+                lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+                errorNotification = randomErrorNotification(),
+                defaultState = states[0].name,
+                states = states
+        )
+
+        createPolicy(policy, policyID)
+        createIndex(indexName)
+
+        // put some metadata into cluster state
+        var indexMetadata = getIndexMetadata(indexName)
+        metadataToClusterState = metadataToClusterState.copy(
+                index = indexName,
+                indexUuid = indexMetadata.indexUUID,
+                policyID = policyID
+        )
+        val request = UpdateManagedIndexMetaDataRequest(
+                indicesToAddManagedIndexMetaDataTo = listOf(
+                        Pair(Index(metadataToClusterState.index, metadataToClusterState.indexUuid), metadataToClusterState)
+                )
+        )
+        val response: AcknowledgedResponse = client().execute(
+                UpdateManagedIndexMetaDataAction.INSTANCE, request).get()
+
+        logger.info(response.isAcknowledged)
+        indexMetadata = getIndexMetadata(indexName)
+        logger.info("check if metadata is saved in cluster state: ${indexMetadata.getCustomData("managed_index_metadata")}")
+
+        // start a job run
+        addPolicyToIndex(indexName, policyID)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+        // Change the start time so the job will trigger in 2 seconds, this will trigger the first initialization of the policy
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        // cluster state metadata is removed, explain API can get metadata from config index
+        waitFor { assertEquals(null, getIndexMetadata(indexName).getCustomData("managed_index_metadata")) }
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+        waitFor { assertEquals("Successfully initialized policy: ${policy.id}", getExplainManagedIndexMetaData(indexName).info?.get("message")) }
+
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals("Index did not set number_of_replicas to ${actionConfig.numOfReplicas}", actionConfig.numOfReplicas, getNumberOfReplicasSetting(indexName)) }
+    }
+
+    fun `test job can continue run from cluster state metadata`() {
+        /**
+         *  create index, add policy to it
+         *  manually add policy field to managed-index so runner won't initialise
+         *  add metadata into cluster state
+         *  then check if we can continue run from this added metadata
+         */
+
+        val indexName = "${testIndexName}_index_2"
+        val policyID = "${testIndexName}_testPolicyName_2"
+        val actionConfig = ReplicaCountActionConfig(10, 0)
+        val states = listOf(State(name = "ReplicaCountState", actions = listOf(actionConfig), transitions = listOf()))
+        val policy = Policy(
+            id = policyID,
+            description = "$testIndexName description",
+            schemaVersion = 1L,
+            lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+            errorNotification = randomErrorNotification(),
+            defaultState = states[0].name,
+            states = states
+        )
+
+        createPolicy(policy, policyID)
+        createIndex(indexName)
+        addPolicyToIndex(indexName, policyID)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+        // manually add policy field into managed-index
+        updateManagedIndexConfigPolicy(managedIndexConfig, policy)
+        logger.info("managed-index: ${getExistingManagedIndexConfig(indexName)}")
+
+        // put some metadata into cluster state
+        var indexMetadata = getIndexMetadata(indexName)
+        metadataToClusterState = metadataToClusterState.copy(
+            index = indexName,
+            indexUuid = indexMetadata.indexUUID,
+            policyID = policyID
+        )
+        val request = UpdateManagedIndexMetaDataRequest(
+            indicesToAddManagedIndexMetaDataTo = listOf(
+                Pair(Index(metadataToClusterState.index, metadataToClusterState.indexUuid), metadataToClusterState)
+            )
+        )
+        val response: AcknowledgedResponse = client().execute(
+                UpdateManagedIndexMetaDataAction.INSTANCE, request).get()
+
+        logger.info(response.isAcknowledged)
+        indexMetadata = getIndexMetadata(indexName)
+        logger.info("check if metadata is saved in cluster state: ${indexMetadata.getCustomData("managed_index_metadata")}")
+
+        // start the job run
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor {
+            assertEquals("Index did not set number_of_replicas to ${actionConfig.numOfReplicas}", actionConfig.numOfReplicas, getNumberOfReplicasSetting(indexName))
+        }
+    }
+
+    fun `test new node skip execution when old node exist in cluster`() {
+        Assume.assumeTrue(isMixedNodeRegressionTest)
+
+        /**
+         * mixedCluster-0 is new node, mixedCluster-1 is old node
+         * set config index to only have one shard on new node
+         * so old node cannot run job because it has no shard
+         * new node also cannot run job because there is an old node
+         * here we check no job can be run
+         *
+         * then reroute shard to old node and this old node can run job
+         */
+
+        val indexName = "${testIndexName}_index_1"
+        val policyID = "${testIndexName}_testPolicyName_1"
+        val actionConfig = ReplicaCountActionConfig(10, 0)
+        val states = listOf(State(name = "ReplicaCountState", actions = listOf(actionConfig), transitions = listOf()))
+        val policy = Policy(
+                id = policyID,
+                description = "$testIndexName description",
+                schemaVersion = 1L,
+                lastUpdatedTime = Instant.now().truncatedTo(ChronoUnit.MILLIS),
+                errorNotification = randomErrorNotification(),
+                defaultState = states[0].name,
+                states = states
+        )
+
+        createPolicy(policy, policyID)
+        createIndex(indexName)
+
+        val configIndexName = ".opendistro-ism-config"
+
+        val settings = Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, "0")
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, "1")
+                .build()
+        updateIndexSettings(configIndexName, settings)
+
+        // check config index shard position
+        val shardsResponse = catIndexShard(configIndexName)
+        logger.info("check config index shard: $shardsResponse")
+        val shardNode = (shardsResponse[0] as HashMap<*, *>)["node"]
+
+        // move shard on node1 to node0 if exist
+        if (shardNode == "mixedCluster-1") rerouteShard(configIndexName, "mixedCluster-1", "mixedCluster-0")
+
+        addPolicyToIndex(indexName, policyID)
+
+        val managedIndexConfig = getExistingManagedIndexConfig(indexName)
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+
+        // check no job has been run
+        wait { assertEquals(null, getExistingManagedIndexConfig(indexName).policy) }
+
+        // reroute shard to node1
+        rerouteShard(configIndexName, "mixedCluster-0", "mixedCluster-1")
+
+        val shardsResponse2 = catIndexShard(configIndexName)
+        logger.info("check config index shard: $shardsResponse2")
+
+        // job can be ran now
+        updateManagedIndexConfigStartTime(managedIndexConfig)
+        waitFor { assertEquals(policyID, getExplainManagedIndexMetaData(indexName).policyID) }
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/TestHelpers.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/TestHelpers.kt
@@ -462,3 +462,22 @@ fun <T> waitFor(
         }
     } while (true)
 }
+
+fun <T> wait(
+    timeout: Instant = Instant.ofEpochSecond(10),
+    block: () -> T
+) {
+    val startTime = Instant.now().toEpochMilli()
+    do {
+        try {
+            block()
+            if ((Instant.now().toEpochMilli() - startTime) > timeout.toEpochMilli()) {
+                return
+            } else {
+                Thread.sleep(100L)
+            }
+        } catch (e: Throwable) {
+            throw e
+        }
+    } while (true)
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/action/ActionRetryIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/action/ActionRetryIT.kt
@@ -20,7 +20,9 @@ import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagemen
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.ActionMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.PolicyRetryInfoMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StateMetaData
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.step.Step
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.step.rollover.AttemptRolloverStep
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.waitFor
 import java.time.Instant
@@ -153,6 +155,11 @@ class ActionRetryIT : IndexStateManagementRestTestCase() {
                             assertActionEquals(
                                 ActionMetaData("rollover", Instant.now().toEpochMilli(), 0, false, 1, null, null),
                                 actionMetaDataMap
+                            ),
+                        StepMetaData.STEP to fun(stepMetaDataMap: Any?): Boolean =
+                            assertStepEquals(
+                                StepMetaData("attempt_rollover", Instant.now().toEpochMilli(), Step.StepStatus.FAILED),
+                                stepMetaDataMap
                             ),
                         PolicyRetryInfoMetaData.RETRY_INFO to fun(retryInfoMetaDataMap: Any?): Boolean =
                             assertRetryInfoEquals(PolicyRetryInfoMetaData(false, 0), retryInfoMetaDataMap),

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/action/IndexStateManagementHistoryIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/action/IndexStateManagementHistoryIT.kt
@@ -25,8 +25,10 @@ import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagemen
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.ActionMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.PolicyRetryInfoMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StateMetaData
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.managedindexmetadata.StepMetaData
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.randomErrorNotification
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.step.Step
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.step.readonly.SetReadOnlyStep
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.waitFor
 import org.elasticsearch.action.search.SearchResponse
@@ -90,7 +92,7 @@ class IndexStateManagementHistoryIT : IndexStateManagementRestTestCase() {
             transitionTo = null,
             stateMetaData = StateMetaData("ReadOnlyState", actualHistory.stateMetaData!!.startTime),
             actionMetaData = ActionMetaData(ActionConfig.ActionType.READ_ONLY.toString(), actualHistory.actionMetaData!!.startTime, 0, false, 0, 0, null),
-            stepMetaData = null,
+            stepMetaData = StepMetaData("set_read_only", actualHistory.stepMetaData!!.startTime, Step.StepStatus.COMPLETED),
             policyRetryInfo = PolicyRetryInfoMetaData(false, 0),
             info = mapOf("message" to SetReadOnlyStep.getSuccessMessage(indexName))
         )
@@ -156,7 +158,7 @@ class IndexStateManagementHistoryIT : IndexStateManagementRestTestCase() {
             transitionTo = null,
             stateMetaData = StateMetaData("ReadOnlyState", actualHistory.stateMetaData!!.startTime),
             actionMetaData = ActionMetaData(ActionConfig.ActionType.READ_ONLY.toString(), actualHistory.actionMetaData!!.startTime, 0, false, 0, 0, null),
-            stepMetaData = null,
+            stepMetaData = StepMetaData("set_read_only", actualHistory.stepMetaData!!.startTime, Step.StepStatus.COMPLETED),
             policyRetryInfo = PolicyRetryInfoMetaData(false, 0),
             info = mapOf("message" to SetReadOnlyStep.getSuccessMessage(indexName))
         )
@@ -222,7 +224,7 @@ class IndexStateManagementHistoryIT : IndexStateManagementRestTestCase() {
             transitionTo = null,
             stateMetaData = StateMetaData("ReadOnlyState", actualHistory.stateMetaData!!.startTime),
             actionMetaData = ActionMetaData(ActionConfig.ActionType.READ_ONLY.toString(), actualHistory.actionMetaData!!.startTime, 0, false, 0, 0, null),
-            stepMetaData = null,
+            stepMetaData = StepMetaData("set_read_only", actualHistory.stepMetaData!!.startTime, Step.StepStatus.COMPLETED),
             policyRetryInfo = PolicyRetryInfoMetaData(false, 0),
             info = mapOf("message" to SetReadOnlyStep.getSuccessMessage(indexName))
         )
@@ -312,7 +314,7 @@ class IndexStateManagementHistoryIT : IndexStateManagementRestTestCase() {
             transitionTo = null,
             stateMetaData = StateMetaData(states[0].name, actualHistory1.stateMetaData!!.startTime),
             actionMetaData = ActionMetaData(ActionConfig.ActionType.READ_ONLY.toString(), actualHistory1.actionMetaData!!.startTime, 0, false, 0, 0, null),
-            stepMetaData = null,
+            stepMetaData = StepMetaData("set_read_only", actualHistory1.stepMetaData!!.startTime, Step.StepStatus.COMPLETED),
             policyRetryInfo = PolicyRetryInfoMetaData(false, 0),
             info = mapOf("message" to SetReadOnlyStep.getSuccessMessage(indexName))
         )

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/action/NotificationActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/action/NotificationActionIT.kt
@@ -89,5 +89,7 @@ class NotificationActionIT : IndexStateManagementRestTestCase() {
 
         // verify index does exist
         waitFor { assertTrue("Notification index does not exist", indexExists(notificationIndex)) }
+
+        waitForStepCompleted(indexName)
     }
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/action/OpenActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/action/OpenActionIT.kt
@@ -64,6 +64,8 @@ class OpenActionIT : IndexStateManagementRestTestCase() {
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
         waitFor { assertEquals("open", getIndexState(indexName)) }
+
+        waitForStepCompleted(indexName)
     }
 
     fun `test already open index`() {
@@ -100,5 +102,7 @@ class OpenActionIT : IndexStateManagementRestTestCase() {
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
         waitFor { assertEquals("open", getIndexState(indexName)) }
+
+        waitForStepCompleted(indexName)
     }
 }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.coordinator
 
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.SkipExecution

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/coordinator/SkipExecutionTests.kt
@@ -1,0 +1,32 @@
+package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.coordinator
+
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.SkipExecution
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoAction
+import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.ClusterChangedEvent
+import org.elasticsearch.cluster.ESAllocationTestCase
+import org.elasticsearch.cluster.service.ClusterService
+import org.junit.Before
+import org.mockito.Mockito
+
+class SkipExecutionTests : ESAllocationTestCase() {
+
+    private lateinit var client: Client
+    private lateinit var clusterService: ClusterService
+    private lateinit var skip: SkipExecution
+
+    @Before
+    @Throws(Exception::class)
+    fun setup() {
+        client = Mockito.mock(Client::class.java)
+        clusterService = Mockito.mock(ClusterService::class.java)
+        skip = SkipExecution(client, clusterService)
+    }
+
+    fun `test cluster change event`() {
+        val event = Mockito.mock(ClusterChangedEvent::class.java)
+        Mockito.`when`(event.nodesChanged()).thenReturn(true)
+        skip.clusterChanged(event)
+        Mockito.verify(client).execute(Mockito.eq(NodesInfoAction.INSTANCE), Mockito.any(), Mockito.any())
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/resthandler/IndexStateManagementRestApiIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/resthandler/IndexStateManagementRestApiIT.kt
@@ -46,25 +46,25 @@ class IndexStateManagementRestApiIT : IndexStateManagementRestTestCase() {
     fun `test plugins are loaded`() {
         val response = entityAsMap(client().makeRequest("GET", "_nodes/plugins"))
         val nodesInfo = response["nodes"] as Map<String, Map<String, Any>>
-        var hasIndexStateMangementPlugin = false
+        var hasIndexStateManagementPlugin = false
         var hasJobSchedulerPlugin = false
         for (nodeInfo in nodesInfo.values) {
             val plugins = nodeInfo["plugins"] as List<Map<String, Any>>
 
             for (plugin in plugins) {
                 if (plugin["name"] == "opendistro_index_management") {
-                    hasIndexStateMangementPlugin = true
+                    hasIndexStateManagementPlugin = true
                 }
                 if (plugin["name"] == "opendistro-job-scheduler") {
                     hasJobSchedulerPlugin = true
                 }
             }
 
-            if (hasIndexStateMangementPlugin && hasJobSchedulerPlugin) {
+            if (hasIndexStateManagementPlugin && hasJobSchedulerPlugin) {
                 return
             }
         }
-        fail("Plugins not installed, ISMPlugin loaded: $hasIndexStateMangementPlugin, JobScheduler loaded: $hasJobSchedulerPlugin")
+        fail("Plugins not installed, ISMPlugin loaded: $hasIndexStateManagementPlugin, JobScheduler loaded: $hasJobSchedulerPlugin")
     }
 
     @Throws(Exception::class)

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/resthandler/RestChangePolicyActionIT.kt
@@ -194,7 +194,7 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         assertNull("Policy has already initialized", managedIndexConfig.policy)
         assertEquals("Policy id does not match", policy.id, managedIndexConfig.policyID)
 
-        // if we try to change policy now, it'll have no ManagedIndexMetaData yet and should succeed
+        // if we try to change policy now, it haven't actually run so have no ManagedIndexMetaData yet, should succeed then
         val changePolicy = ChangePolicy(newPolicy.id, null, emptyList(), false)
         val response = client().makeRequest(RestRequest.Method.POST.toString(),
                 "${RestChangePolicyAction.CHANGE_POLICY_BASE_URI}/$index", emptyMap(), changePolicy.toHttpEntity())
@@ -206,10 +206,14 @@ class RestChangePolicyActionIT : IndexStateManagementRestTestCase() {
         // speed up to first execution where we initialize the policy on the job
         updateManagedIndexConfigStartTime(managedIndexConfig)
 
-        waitFor { assertEquals(newPolicy.id, getManagedIndexConfigByDocId(managedIndexConfig.id)?.policyID) }
+        val updatedManagedIndexConfig = waitFor {
+            // TODO: get by docID could get older version of the doc which could cause flaky failure
+            val config = getManagedIndexConfigByDocId(managedIndexConfig.id)
+            assertEquals(newPolicy.id, config?.policyID)
+            config
+        }
 
         // The initialized policy should be the change policy one
-        val updatedManagedIndexConfig = getManagedIndexConfigByDocId(managedIndexConfig.id)
         assertNotNull("Updated managed index config is null", updatedManagedIndexConfig)
         assertNull("Updated change policy is not null", updatedManagedIndexConfig!!.changePolicy)
         assertEquals("Initialized policyId is not the change policy id", newPolicy.id, updatedManagedIndexConfig.policyID)

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/resthandler/RestRetryFailedManagedIndexActionIT.kt
@@ -85,7 +85,7 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
                 mapOf(
                     "index_name" to indexName1,
                     "index_uuid" to getUuid(indexName1),
-                    "reason" to "There is no IndexMetaData information"
+                    "reason" to "This index has no metadata information"
                 )
             )
         )
@@ -107,6 +107,7 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
             "${RestRetryFailedManagedIndexAction.RETRY_BASE_URI}/$indexName*"
         )
         assertEquals("Unexpected RestStatus", RestStatus.OK, response.restStatus())
+
         val actualMessage = response.asMap()
         val expectedErrorMessage = mapOf(
             FAILURES to true,
@@ -125,7 +126,7 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
                 mapOf(
                     "index_name" to indexName2,
                     "index_uuid" to getUuid(indexName2),
-                    "reason" to "There is no IndexMetaData information"
+                    "reason" to "This index has no metadata information"
                 )
             )
         )
@@ -158,6 +159,7 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
     fun `test index has no metadata`() {
         val indexName = "${testIndexName}_players"
         createIndex(indexName, "somePolicy")
+
         val response = client().makeRequest(
             RestRequest.Method.POST.toString(),
             "${RestRetryFailedManagedIndexAction.RETRY_BASE_URI}/$indexName"
@@ -171,7 +173,7 @@ class RestRetryFailedManagedIndexActionIT : IndexStateManagementRestTestCase() {
                 mapOf(
                     "index_name" to indexName,
                     "index_uuid" to getUuid(indexName),
-                    "reason" to "There is no IndexMetaData information"
+                    "reason" to "This index has no metadata information"
                 )
             )
         )

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/runner/ManagedIndexRunnerTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/runner/ManagedIndexRunnerTests.kt
@@ -1,0 +1,130 @@
+package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.runner
+
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.IndexStateManagementHistory
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.ManagedIndexRunner
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.SkipExecution
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.model.ManagedIndexMetaData
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.settings.ManagedIndexSettings
+import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.transport.action.updateindexmetadata.UpdateManagedIndexMetaDataRequest
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
+import org.elasticsearch.Version
+import org.elasticsearch.action.ActionListener
+import org.elasticsearch.action.index.IndexResponse
+import org.elasticsearch.action.support.master.AcknowledgedResponse
+import org.elasticsearch.client.Client
+import org.elasticsearch.cluster.node.DiscoveryNode
+import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.common.settings.ClusterSettings
+import org.elasticsearch.common.settings.Setting
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.xcontent.NamedXContentRegistry
+import org.elasticsearch.env.Environment
+import org.elasticsearch.rest.RestStatus
+import org.elasticsearch.script.ScriptService
+import org.elasticsearch.test.ClusterServiceUtils
+import org.elasticsearch.test.ESTestCase
+import org.elasticsearch.threadpool.ThreadPool
+import org.junit.Before
+import org.mockito.Mockito
+
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+class ManagedIndexRunnerTests : ESTestCase() {
+
+    private lateinit var client: Client
+    private lateinit var clusterService: ClusterService
+    private lateinit var xContentRegistry: NamedXContentRegistry
+    private lateinit var scriptService: ScriptService
+    private lateinit var environment: Environment
+    private lateinit var indexStateManagementHistory: IndexStateManagementHistory
+    private lateinit var skipFlag: SkipExecution
+    private lateinit var runner: ManagedIndexRunner
+
+    private lateinit var settings: Settings
+    private lateinit var discoveryNode: DiscoveryNode
+    private lateinit var threadPool: ThreadPool
+
+    private lateinit var indexResponse: IndexResponse
+
+    @Before
+    @Throws(Exception::class)
+    fun setup() {
+        clusterService = Mockito.mock(ClusterService::class.java)
+        xContentRegistry = Mockito.mock(NamedXContentRegistry::class.java)
+        scriptService = Mockito.mock(ScriptService::class.java)
+        environment = Mockito.mock(Environment::class.java)
+        indexStateManagementHistory = Mockito.mock(IndexStateManagementHistory::class.java)
+        skipFlag = Mockito.mock(SkipExecution::class.java)
+
+        threadPool = Mockito.mock(ThreadPool::class.java)
+        settings = Settings.builder().build()
+        discoveryNode = DiscoveryNode("node", buildNewFakeTransportAddress(), Version.CURRENT)
+        val settingSet = hashSetOf<Setting<*>>()
+        settingSet.addAll(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        settingSet.add(ManagedIndexSettings.SWEEP_PERIOD)
+        settingSet.add(ManagedIndexSettings.JOB_INTERVAL)
+        settingSet.add(ManagedIndexSettings.INDEX_STATE_MANAGEMENT_ENABLED)
+        settingSet.add(ManagedIndexSettings.ALLOW_LIST)
+        val clusterSettings = ClusterSettings(settings, settingSet)
+        val originClusterService: ClusterService = ClusterServiceUtils.createClusterService(threadPool, discoveryNode, clusterSettings)
+        clusterService = Mockito.spy(originClusterService)
+
+        Mockito.`when`(environment.settings()).thenReturn(settings)
+
+        runner = ManagedIndexRunner
+                .registerClusterService(clusterService)
+                .registerNamedXContentRegistry(xContentRegistry)
+                .registerScriptService(scriptService)
+                .registerSettings(environment.settings())
+                .registerConsumers()
+                .registerHistoryIndex(indexStateManagementHistory)
+                .registerSkipFlag(skipFlag)
+    }
+
+    fun `test fail to delete metadata in cluster state`() {
+        /**
+         * if delete metadata in cluster state not successful
+         * check `metadataDeleted` is false
+         */
+
+        val acknowledgedResponse = AcknowledgedResponse(false)
+        indexResponse = Mockito.mock(IndexResponse::class.java)
+        Mockito.`when`(indexResponse.status()).thenReturn(RestStatus.CREATED)
+        client = Mockito.mock(Client::class.java)
+        doAnswer { invocationOnMock ->
+            val listener = invocationOnMock.getArgument<ActionListener<AcknowledgedResponse>>(2)
+            listener.onResponse(acknowledgedResponse)
+        }.whenever(client).execute(any(), any<UpdateManagedIndexMetaDataRequest>(), any<ActionListener<AcknowledgedResponse>>())
+        doAnswer { invocationOnMock ->
+            val listener = invocationOnMock.getArgument<ActionListener<IndexResponse>>(1)
+            listener.onResponse(indexResponse)
+        }.whenever(client).index(any(), any())
+
+        runner.registerClient(client)
+
+        val metadata = null
+        val metadata2 = ManagedIndexMetaData(
+                index = "test",
+                indexUuid = "123",
+                policyID = "456",
+                policySeqNo = null,
+                policyPrimaryTerm = null,
+                policyCompleted = false,
+                rolledOver = false,
+                transitionTo = null,
+                stateMetaData = null,
+                actionMetaData = null,
+                stepMetaData = null,
+                policyRetryInfo = null,
+                info = mapOf("message" to "hello"))
+
+        runBlocking {
+            assertEquals(true, runner.metadataDeleted)
+            runner.handleClusterStateMetadata(metadata, metadata2)
+            assertEquals(false, runner.metadataDeleted)
+        }
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/runner/ManagedIndexRunnerTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/runner/ManagedIndexRunnerTests.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.runner
 
 import com.amazon.opendistroforelasticsearch.indexmanagement.indexstatemanagement.IndexStateManagementHistory

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -535,7 +535,7 @@
               "type": "long"
             },
             "step_status": {
-              "type": "text"
+              "type": "keyword"
             }
           }
         },

--- a/src/test/resources/mappings/cached-opendistro-ism-config.json
+++ b/src/test/resources/mappings/cached-opendistro-ism-config.json
@@ -1,6 +1,6 @@
 {
   "_meta" : {
-    "schema_version": 4
+    "schema_version": 5
   },
   "dynamic": "strict",
   "properties": {
@@ -425,6 +425,133 @@
               }
             }
           }
+        }
+      }
+    },
+    "managed_index_metadata": {
+      "properties": {
+        "index": {
+          "type" : "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "index_uuid": {
+          "type" : "keyword"
+        },
+        "policy_id": {
+          "type" : "keyword"
+        },
+        "policy_seq_no": {
+          "type": "long"
+        },
+        "policy_primary_term": {
+          "type": "long"
+        },
+        "policy_completed": {
+          "type": "boolean"
+        },
+        "rolled_over": {
+          "type": "boolean"
+        },
+        "transition_to": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
+        },
+        "state": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "start_time": {
+              "type": "long"
+            }
+          }
+        },
+        "action": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "start_time": {
+              "type": "long"
+            },
+            "index": {
+              "type": "integer"
+            },
+            "failed": {
+              "type": "boolean"
+            },
+            "consumed_retries": {
+              "type": "integer"
+            },
+            "last_retry_time": {
+              "type": "long"
+            },
+            "action_properties": {
+              "properties": {
+                "max_num_segments": {
+                  "type": "integer"
+                },
+                "snapshot_name": {
+                  "type": "text"
+                }
+              }
+            }
+          }
+        },
+        "step": {
+          "properties": {
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "start_time": {
+              "type": "long"
+            },
+            "step_status": {
+              "type": "text"
+            }
+          }
+        },
+        "retry_info": {
+          "properties": {
+            "failed": {
+              "type": "boolean"
+            },
+            "consumed_retries": {
+              "type": "integer"
+            }
+          }
+        },
+        "info": {
+          "type": "object",
+          "enabled": false
         }
       }
     }


### PR DESCRIPTION
*Issue #, if available:*
#207 

*Description of changes:*
Previously we save job metadata to cluster state, which will be a performance constraint when there are thousands of parallel running job. Now we save job metadata to our configuration index to relieve this performance concern.

- What if cluster has 2 version of ISM plugin (like during upgrading)
   - The node with new version ISM plugin will skip execution if there is node with old version ISM plugin
   - The node with old version ISM plugin can still run ISM job
   - After all nodes upgraded, our new version ISM plugin will move metadata from cluster state to config index, and delete metadata left in cluster state

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
