### PR TITLE
Fix handling various date formats for DateHistogram source field in continuous Rollups

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMetadataService.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMetadataService.kt
@@ -52,7 +52,6 @@ import org.elasticsearch.search.builder.SearchSourceBuilder
 import org.elasticsearch.search.sort.SortOrder
 import org.elasticsearch.transport.RemoteTransportException
 import java.time.Instant
-import java.time.ZonedDateTime
 
 // TODO: Wrap client calls in retry for transient failures
 // Service that handles CRUD operations for rollup metadata

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMetadataService.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMetadataService.kt
@@ -24,6 +24,7 @@ import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.Rollup
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.RollupMetadata.Companion.NO_ID
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.RollupStats
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.dimension.DateHistogram
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.util.DATE_FIELD_EPOCH_MILLIS_FORMAT
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.apache.logging.log4j.LogManager
@@ -181,7 +182,8 @@ class RollupMetadataService(val client: Client, val xContentRegistry: NamedXCont
                 .query(MatchAllQueryBuilder())
                 .sort(dateHistogram.sourceField, SortOrder.ASC) // TODO: figure out where nulls are sorted
                 .trackTotalHits(false)
-                .fetchSource(dateHistogram.sourceField, null)
+                .fetchSource(false)
+                .docValueField(dateHistogram.sourceField, DATE_FIELD_EPOCH_MILLIS_FORMAT)
             val searchRequest = SearchRequest(rollup.sourceIndex)
                 .source(searchSourceBuilder)
                 .allowPartialSearchResults(false)
@@ -192,9 +194,12 @@ class RollupMetadataService(val client: Client, val xContentRegistry: NamedXCont
                 return StartingTimeResult.NoDocumentsFound
             }
 
-            val firstSource = response.hits.hits.first().sourceAsMap[dateHistogram.sourceField] as String
+            // Get the doc value field of the dateHistogram.sourceField for the first search hit converted to epoch millis
+            // If the doc value is null or empty it will be treated the same as empty doc hits
+            val firstHitTimestamp = response.hits.hits.first().field(dateHistogram.sourceField).getValue<String>()?.toLong()
+                ?: return StartingTimeResult.NoDocumentsFound
 
-            return StartingTimeResult.Success(getRoundedTime(firstSource, dateHistogram))
+            return StartingTimeResult.Success(getRoundedTime(firstHitTimestamp, dateHistogram))
         } catch (e: RemoteTransportException) {
             val unwrappedException = ExceptionsHelper.unwrapCause(e) as Exception
             logger.debug("Error when getting initial start time for rollup [${rollup.id}]: $unwrappedException")
@@ -210,13 +215,11 @@ class RollupMetadataService(val client: Client, val xContentRegistry: NamedXCont
      * Return time rounded down to the nearest unit of time the interval is based on.
      * This should map to the equivalent bucket a document with the given timestamp would fall into for the date histogram.
      */
-    private fun getRoundedTime(timestamp: String, dateHistogram: DateHistogram): Instant {
+    private fun getRoundedTime(timestamp: Long, dateHistogram: DateHistogram): Instant {
         val roundingStrategy = getRoundingStrategy(dateHistogram)
-        val timeInMillis = ZonedDateTime.parse(timestamp).toInstant().toEpochMilli()
-
         val roundedMillis = roundingStrategy
-            .prepare(timeInMillis, timeInMillis)
-            .round(timeInMillis)
+            .prepare(timestamp, timestamp)
+            .round(timestamp)
         return Instant.ofEpochMilli(roundedMillis)
     }
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/util/RollupUtils.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/util/RollupUtils.kt
@@ -71,11 +71,14 @@ import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder
 import org.elasticsearch.search.aggregations.metrics.ValueCountAggregationBuilder
 import org.elasticsearch.search.builder.SearchSourceBuilder
 
+const val DATE_FIELD_EPOCH_MILLIS_FORMAT = "epoch_millis"
+
 fun Rollup.getRollupSearchRequest(metadata: RollupMetadata): SearchRequest {
     val query = if (metadata.continuous != null) {
         RangeQueryBuilder(this.getDateHistogram().sourceField)
             .from(metadata.continuous.nextWindowStartTime.toEpochMilli(), true)
             .to(metadata.continuous.nextWindowEndTime.toEpochMilli(), false)
+            .format(DATE_FIELD_EPOCH_MILLIS_FORMAT)
     } else {
         MatchAllQueryBuilder()
     }

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMetadataServiceTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMetadataServiceTests.kt
@@ -34,9 +34,9 @@ import org.elasticsearch.action.search.SearchResponse
 import org.elasticsearch.client.Client
 import org.elasticsearch.common.bytes.BytesArray
 import org.elasticsearch.common.bytes.BytesReference
+import org.elasticsearch.common.document.DocumentField
 import org.elasticsearch.common.xcontent.NamedXContentRegistry
 import org.elasticsearch.common.xcontent.ToXContent
-import org.elasticsearch.common.xcontent.XContentFactory
 import org.elasticsearch.search.SearchHit
 import org.elasticsearch.search.SearchHits
 import org.elasticsearch.test.ESTestCase
@@ -47,6 +47,8 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
+// TODO: Given the way these tests are mocking data, only entries that work with ZonedDateTime.parse
+//   are being tested, should mock the data more generically to test all cases
 class RollupMetadataServiceTests : ESTestCase() {
 
     private lateinit var xContentRegistry: NamedXContentRegistry
@@ -711,13 +713,9 @@ class RollupMetadataServiceTests : ESTestCase() {
 
         // TODO: Mockito 2 supposedly should be able to mock final classes but there were errors when trying to do so
         //   Will need to check if there is a workaround or a better way to mock getting hits.hits since this current approach is verbose
-        val sourceAsBytes = BytesReference.bytes(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .field(dateHistogram.sourceField, timestamp)
-                .endObject()
-        )
-        val searchHit = SearchHit(0).sourceRef(sourceAsBytes)
+        val docField = DocumentField(dateHistogram.sourceField, listOf(getInstant(timestamp).toEpochMilli().toString()))
+        val searchHit = SearchHit(0)
+        searchHit.setDocumentField(dateHistogram.sourceField, docField)
         val searchHits = SearchHits(arrayOf(searchHit), null, 0.0F)
 
         val searchResponse: SearchResponse = mock()


### PR DESCRIPTION
*Issue #, if available:* #374

*Description of changes:*
Continuous rollups encountered parse exceptions for certain date formats, this fix converts
the date field to epoch millis before calculating start and end time so that the logic is date format agnostic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
