### PR TITLE
Field cap fix

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/IndexManagementPlugin.kt
@@ -154,6 +154,10 @@ internal class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, Act
 
     override fun getJobRunner(): ScheduledJobRunner = IndexManagementRunner
 
+    override fun getGuiceServiceClasses(): Collection<Class<out LifecycleComponent?>> {
+        return mutableListOf<Class<out LifecycleComponent?>>(GuiceHolder::class.java)
+    }
+
     override fun getJobParser(): ScheduledJobParser {
         return ScheduledJobParser { xcp, id, jobDocVersion ->
             ensureExpectedToken(Token.START_OBJECT, xcp.nextToken(), xcp)

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/IndexManagementPlugin.kt
@@ -135,6 +135,7 @@ internal class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, Act
     lateinit var clusterService: ClusterService
     lateinit var indexNameExpressionResolver: IndexNameExpressionResolver
     lateinit var rollupInterceptor: RollupInterceptor
+    lateinit var fieldCapsFilter: FieldCapsFilter
 
     companion object {
         const val PLUGIN_NAME = "opendistro-im"
@@ -247,6 +248,7 @@ internal class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, Act
             .registerMetadataServices(RollupMetadataService(client, xContentRegistry))
             .registerConsumers()
         rollupInterceptor = RollupInterceptor(clusterService, settings, indexNameExpressionResolver)
+        fieldCapsFilter = FieldCapsFilter(clusterService, settings, indexNameExpressionResolver)
         this.indexNameExpressionResolver = indexNameExpressionResolver
 
         val skipFlag = SkipExecution(client, clusterService)
@@ -303,7 +305,8 @@ internal class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, Act
             RollupSettings.ROLLUP_SEARCH_BACKOFF_MILLIS,
             RollupSettings.ROLLUP_INDEX,
             RollupSettings.ROLLUP_ENABLED,
-            RollupSettings.ROLLUP_SEARCH_ENABLED
+            RollupSettings.ROLLUP_SEARCH_ENABLED,
+            RollupSettings.ROLLUP_DASHBOARDS
         )
     }
 
@@ -336,7 +339,7 @@ internal class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, Act
     }
 
     override fun getActionFilters(): List<ActionFilter> {
-        return listOf(FieldCapsFilter(clusterService, indexNameExpressionResolver))
+        return listOf(fieldCapsFilter)
     }
 }
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/IndexManagementPlugin.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/IndexManagementPlugin.kt
@@ -121,6 +121,12 @@ import org.elasticsearch.threadpool.ThreadPool
 import org.elasticsearch.transport.TransportInterceptor
 import org.elasticsearch.watcher.ResourceWatcherService
 import java.util.function.Supplier
+import org.elasticsearch.common.component.Lifecycle
+import org.elasticsearch.common.component.LifecycleComponent
+import org.elasticsearch.common.component.LifecycleListener
+import org.elasticsearch.common.inject.Inject
+import org.elasticsearch.transport.RemoteClusterService
+import org.elasticsearch.transport.TransportService
 
 internal class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, ActionPlugin, Plugin() {
 
@@ -327,5 +333,27 @@ internal class IndexManagementPlugin : JobSchedulerExtension, NetworkPlugin, Act
 
     override fun getActionFilters(): List<ActionFilter> {
         return listOf(FieldCapsFilter(clusterService, indexNameExpressionResolver))
+    }
+}
+
+class GuiceHolder @Inject constructor(
+    remoteClusterService: TransportService
+) : LifecycleComponent {
+    override fun close() {}
+    override fun lifecycleState(): Lifecycle.State? {
+        return null
+    }
+
+    override fun addLifecycleListener(listener: LifecycleListener) {}
+    override fun removeLifecycleListener(listener: LifecycleListener) {}
+    override fun start() {}
+    override fun stop() {}
+
+    companion object {
+        lateinit var remoteClusterService: RemoteClusterService
+    }
+
+    init {
+        Companion.remoteClusterService = remoteClusterService.remoteClusterService
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
@@ -90,7 +90,7 @@ class FieldCapsFilter(
                     nonRollupIndices.add("$cluster${RemoteClusterAware.REMOTE_CLUSTER_INDEX_SEPARATOR}$index")
                 }
             }
-            logger.info("Resolved into rollup $rollupIndices and non rollup $nonRollupIndices indices")
+            logger.debug("Resolved into rollup $rollupIndices and non rollup $nonRollupIndices indices")
 
             if (rollupIndices.isEmpty()) {
                 return chain.proceed(task, action, request, listener)

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
@@ -132,7 +132,7 @@ class FieldCapsFilter(
      * Unfortunately this is package private and when rewriting we can't access it from request. Instead will be relying on the response.
      * If response has indexResponses then its unmerged else merged.
      */
-    private fun rewriteResponse(response: FieldCapabilitiesResponse, rollupIndices: Set<String>, shouldDiscardResponse: Boolean): ActionResponse {
+    internal fun rewriteResponse(response: FieldCapabilitiesResponse, rollupIndices: Set<String>, shouldDiscardResponse: Boolean): ActionResponse {
         val ismFieldCapabilitiesResponse = ISMFieldCapabilitiesResponse.fromFieldCapabilitiesResponse(response)
         val isMergedResponse = ismFieldCapabilitiesResponse.indexResponses.isEmpty()
 

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/FieldCapsFilter.kt
@@ -96,6 +96,14 @@ class FieldCapsFilter(
                 return chain.proceed(task, action, request, listener)
             }
 
+            /**
+             * The request can be one of two cases:
+             * 1  Just rollup indices
+             * 2  Rollup + NonRollup indices
+             * If 1 we forward the request to chain and discard the whole response from chain when rewriting.
+             * If 2 we forward the request to chain with only non rollup indices and append rollup data to response when rewriting.
+             * We are calling with rollup indices in 1 instead of an empty request since empty is defaulted to returning all indices in cluster.
+            **/
             if (nonRollupIndices.isNotEmpty()) {
                 request.indices(*nonRollupIndices.toTypedArray())
             }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeHelper.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeHelper.kt
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistroforelasticsearch.indexmanagement.rollup.actionfilter
 
+import java.util.Objects
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponse
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse
 import org.elasticsearch.common.io.stream.BytesStreamOutput
 import org.elasticsearch.common.io.stream.StreamInput

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeHelper.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeHelper.kt
@@ -57,11 +57,7 @@ class ISMFieldCapabilitiesResponse(
     val indices: Array<String>,
     val responseMap: Map<String, Map<String, ISMFieldCapabilities>>,
     val indexResponses: List<ISMFieldCapabilitiesIndexResponse>
-) : Writeable {
-
-    override fun writeTo(out: StreamOutput?) {
-        TODO("Not yet implemented")
-    }
+) {
 
     fun toFieldCapabilitiesResponse(): FieldCapabilitiesResponse {
         val out = BytesStreamOutput()

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeHelper.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeHelper.kt
@@ -15,8 +15,6 @@
 
 package com.amazon.opendistroforelasticsearch.indexmanagement.rollup.actionfilter
 
-import java.util.Objects
-import org.elasticsearch.action.fieldcaps.FieldCapabilitiesIndexResponse
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse
 import org.elasticsearch.common.io.stream.BytesStreamOutput
 import org.elasticsearch.common.io.stream.StreamInput

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeHelper.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeHelper.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.rollup.actionfilter
+
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse
+import org.elasticsearch.common.io.stream.BytesStreamOutput
+import org.elasticsearch.common.io.stream.StreamInput
+import org.elasticsearch.common.io.stream.StreamOutput
+import org.elasticsearch.common.io.stream.Writeable
+
+/**
+ * To support rollup indices being returned in correct format in FieldCaps API we have to rewrite the FieldCapabilitiesResponse
+ * with correct rollup index's mappings. However many methods/constructors of FieldCapabilitiesResponse class are package private.
+ * To achieve the rewrite despite limitations, the following data classes have been defined so we can modify the ByteStream of
+ * FieldCapabilitiesResponse to include correct rollup mappings and convert it back to FieldCapabilitiesResponse.
+ *
+ * TODO: When/if FieldCapabilitiesResponse and other subclasses package private constructors are elevated to public we can remove this logic.
+ */
+
+class ISMFieldCapabilitiesIndexResponse(
+    private val indexName: String,
+    private val responseMap: Map<String, ISMIndexFieldCapabilities>,
+    private val canMatch: Boolean
+) : Writeable {
+
+    constructor(sin: StreamInput) : this(
+        indexName = sin.readString(),
+        responseMap = sin.readMap({ it.readString() }, { ISMIndexFieldCapabilities(it) }),
+        canMatch = sin.readBoolean()
+    )
+
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(indexName)
+        out.writeMap(
+            responseMap,
+            { writer, value -> writer.writeString(value) },
+            { writer, value -> value.writeTo(writer) }
+        )
+        out.writeBoolean(canMatch)
+    }
+}
+
+class ISMFieldCapabilitiesResponse(
+    val indices: Array<String>,
+    val responseMap: Map<String, Map<String, ISMFieldCapabilities>>,
+    val indexResponses: List<ISMFieldCapabilitiesIndexResponse>
+) : Writeable {
+
+    override fun writeTo(out: StreamOutput?) {
+        TODO("Not yet implemented")
+    }
+
+    fun toFieldCapabilitiesResponse(): FieldCapabilitiesResponse {
+        val out = BytesStreamOutput()
+        out.writeStringArray(indices)
+        out.writeMap(
+            responseMap,
+            { writer, value -> writer.writeString(value) },
+            { writer, value -> writer.writeMap(value, { w, v -> w.writeString(v) }, { w, v -> v.writeTo(w) }) }
+        )
+        out.writeList(indexResponses)
+        val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+        return FieldCapabilitiesResponse(sin)
+    }
+
+    companion object {
+        fun fromFieldCapabilitiesResponse(response: FieldCapabilitiesResponse): ISMFieldCapabilitiesResponse {
+            val out = BytesStreamOutput().also { response.writeTo(it) }
+            val sin = StreamInput.wrap(out.bytes().toBytesRef().bytes)
+            val indices = sin.readStringArray()
+            val responseMap = sin.readMap({ it.readString() }, { it.readMap({ it.readString() }, ::ISMFieldCapabilities) })
+            val indexResponses = sin.readList { ISMFieldCapabilitiesIndexResponse(it) }
+            return ISMFieldCapabilitiesResponse(indices, responseMap, indexResponses)
+        }
+    }
+}
+
+class ISMFieldCapabilities(
+    private val name: String,
+    private val type: String,
+    private val isSearchable: Boolean,
+    private val isAggregatable: Boolean,
+    private val indices: Array<String>?,
+    private val nonSearchableIndices: Array<String>?,
+    private val nonAggregatableIndices: Array<String>?,
+    private val meta: Map<String, Set<String>>
+) : Writeable {
+
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(name)
+        out.writeString(type)
+        out.writeBoolean(isSearchable)
+        out.writeBoolean(isAggregatable)
+        out.writeOptionalStringArray(indices)
+        out.writeOptionalStringArray(nonSearchableIndices)
+        out.writeOptionalStringArray(nonAggregatableIndices)
+        out.writeMap(
+            meta,
+            { writer, value -> writer.writeString(value) },
+            { writer, value -> writer.writeCollection(value) { w, v -> w.writeString(v) } }
+        )
+    }
+
+    constructor(sin: StreamInput) : this(
+        name = sin.readString(),
+        type = sin.readString(),
+        isSearchable = sin.readBoolean(),
+        isAggregatable = sin.readBoolean(),
+        indices = sin.readOptionalStringArray(),
+        nonSearchableIndices = sin.readOptionalStringArray(),
+        nonAggregatableIndices = sin.readOptionalStringArray(),
+        meta = sin.readMap({ it.readString() }, { it.readSet { it.readString() } })
+    )
+}
+
+class ISMIndexFieldCapabilities(
+    private val name: String,
+    private val type: String,
+    private val isSearchable: Boolean,
+    private val isAggregatable: Boolean,
+    private val meta: Map<String, String>
+) : Writeable {
+
+    constructor(sin: StreamInput) : this(
+        name = sin.readString(),
+        type = sin.readString(),
+        isSearchable = sin.readBoolean(),
+        isAggregatable = sin.readBoolean(),
+        meta = sin.readMap({ it.readString() }, { it.readString() })
+    )
+
+    override fun writeTo(out: StreamOutput) {
+        out.writeString(name)
+        out.writeString(type)
+        out.writeBoolean(isSearchable)
+        out.writeBoolean(isAggregatable)
+        out.writeMap(
+            meta,
+            { writer, value: String -> writer.writeString(value) },
+            { writer, value: String -> writer.writeString(value) }
+        )
+    }
+}

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/settings/RollupSettings.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/settings/RollupSettings.kt
@@ -77,5 +77,12 @@ class RollupSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
         )
+
+        val ROLLUP_DASHBOARDS: Setting<Boolean> = Setting.boolSetting(
+            "opendistro.rollup.dashboards",
+            DEFAULT_ROLLUP_ENABLED,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        )
     }
 }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/settings/RollupSettings.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/settings/RollupSettings.kt
@@ -79,7 +79,7 @@ class RollupSettings {
         )
 
         val ROLLUP_DASHBOARDS: Setting<Boolean> = Setting.boolSetting(
-            "opendistro.rollup.dashboards",
+            "opendistro.rollup.dashboards.enabled",
             DEFAULT_ROLLUP_ENABLED,
             Setting.Property.NodeScope,
             Setting.Property.Dynamic

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/TestHelpers.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/TestHelpers.kt
@@ -18,6 +18,10 @@ package com.amazon.opendistroforelasticsearch.indexmanagement.rollup
 import com.amazon.opendistroforelasticsearch.indexmanagement.elasticapi.string
 import com.amazon.opendistroforelasticsearch.indexmanagement.randomInstant
 import com.amazon.opendistroforelasticsearch.indexmanagement.randomSchedule
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.actionfilter.ISMFieldCapabilities
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.actionfilter.ISMFieldCapabilitiesIndexResponse
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.actionfilter.ISMFieldCapabilitiesResponse
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.actionfilter.ISMIndexFieldCapabilities
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.ContinuousMetadata
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.ExplainRollup
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.ISMRollup
@@ -179,6 +183,45 @@ fun randomISMRollup(): ISMRollup {
         pageSize = ESRestTestCase.randomIntBetween(1, 10000),
         dimensions = randomRollupDimensions(),
         metrics = ESRestTestCase.randomList(20, ::randomRollupMetrics).distinctBy { it.targetField }
+    )
+}
+
+fun randomISMFieldCapabilities(): ISMFieldCapabilities {
+    return ISMFieldCapabilities(
+        name = ESRestTestCase.randomAlphaOfLength(10),
+        type = ESRestTestCase.randomAlphaOfLength(10),
+        isSearchable = ESRestTestCase.randomBoolean(),
+        isAggregatable = ESRestTestCase.randomBoolean(),
+        indices = ESRestTestCase.generateRandomStringArray(10, 10, true, true),
+        nonSearchableIndices = ESRestTestCase.generateRandomStringArray(10, 10, true, true),
+        nonAggregatableIndices = ESRestTestCase.generateRandomStringArray(10, 10, true, true),
+        meta = mapOf(ESRestTestCase.randomAlphaOfLength(10) to setOf(ESRestTestCase.randomAlphaOfLength(10)) )
+    )
+}
+
+fun randomISMIndexFieldCapabilities(): ISMIndexFieldCapabilities {
+    return ISMIndexFieldCapabilities(
+        name = ESRestTestCase.randomAlphaOfLength(10),
+        type = ESRestTestCase.randomAlphaOfLength(10),
+        isSearchable = ESRestTestCase.randomBoolean(),
+        isAggregatable = ESRestTestCase.randomBoolean(),
+        meta = mapOf(ESRestTestCase.randomAlphaOfLength(10) to ESRestTestCase.randomAlphaOfLength(10))
+    )
+}
+
+fun randomISMFieldCapabilitiesIndexResponse(): ISMFieldCapabilitiesIndexResponse {
+    return ISMFieldCapabilitiesIndexResponse(
+        indexName = ESRestTestCase.randomAlphaOfLength(10),
+        responseMap = mapOf(ESRestTestCase.randomAlphaOfLength(10) to randomISMIndexFieldCapabilities()),
+        canMatch = ESRestTestCase.randomBoolean()
+    )
+}
+
+fun randomISMFieldCaps(): ISMFieldCapabilitiesResponse {
+    return ISMFieldCapabilitiesResponse(
+        indices = ESRestTestCase.generateRandomStringArray(10, 10, false),
+        responseMap = mapOf(ESRestTestCase.randomAlphaOfLength(10) to mapOf(ESRestTestCase.randomAlphaOfLength(10) to randomISMFieldCapabilities())),
+        indexResponses = ESRestTestCase.randomList(4, ::randomISMFieldCapabilitiesIndexResponse)
     )
 }
 

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/TestHelpers.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/TestHelpers.kt
@@ -195,7 +195,7 @@ fun randomISMFieldCapabilities(): ISMFieldCapabilities {
         indices = ESRestTestCase.generateRandomStringArray(10, 10, true, true),
         nonSearchableIndices = ESRestTestCase.generateRandomStringArray(10, 10, true, true),
         nonAggregatableIndices = ESRestTestCase.generateRandomStringArray(10, 10, true, true),
-        meta = mapOf(ESRestTestCase.randomAlphaOfLength(10) to setOf(ESRestTestCase.randomAlphaOfLength(10)) )
+        meta = mapOf(ESRestTestCase.randomAlphaOfLength(10) to setOf(ESRestTestCase.randomAlphaOfLength(10)))
     )
 }
 

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/FieldCapsFilterTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/FieldCapsFilterTests.kt
@@ -34,7 +34,7 @@ import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.test.ESTestCase
 import org.junit.Before
 
-class FieldCapsFilterTests: ESTestCase() {
+class FieldCapsFilterTests : ESTestCase() {
     private val indexNameExpressionResolver: IndexNameExpressionResolver = mock()
     private val clusterService: ClusterService = mock()
     private val clusterState: ClusterState = mock()

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/FieldCapsFilterTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/FieldCapsFilterTests.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.indexmanagement.rollup.actionfilter
+
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.model.Rollup
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.randomISMFieldCapabilitiesIndexResponse
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.randomISMFieldCaps
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.randomRollup
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.settings.RollupSettings
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse
+import org.elasticsearch.cluster.ClusterState
+import org.elasticsearch.cluster.metadata.IndexMetadata
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver
+import org.elasticsearch.cluster.metadata.Metadata
+import org.elasticsearch.cluster.service.ClusterService
+import org.elasticsearch.common.settings.ClusterSettings
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.test.ESTestCase
+import org.junit.Before
+
+class FieldCapsFilterTests: ESTestCase() {
+    private val indexNameExpressionResolver: IndexNameExpressionResolver = mock()
+    private val clusterService: ClusterService = mock()
+    private val clusterState: ClusterState = mock()
+    private val metadata: Metadata = mock()
+    private val settings: Settings = Settings.EMPTY
+    private val indexMetadata: IndexMetadata = mock()
+    private val rollupIndex: String = "dummy-rollupIndex"
+    private val rollup: Rollup = randomRollup()
+
+    @Before
+    fun setupSettings() {
+        whenever(clusterService.clusterSettings).doReturn(ClusterSettings(Settings.EMPTY, setOf(RollupSettings.ROLLUP_DASHBOARDS)))
+        whenever(clusterService.state()).doReturn(clusterState)
+        whenever(clusterState.metadata).doReturn(metadata)
+        whenever(metadata.index(rollupIndex)).doReturn(indexMetadata)
+    }
+
+    fun `test rewrite unmerged response`() {
+        val fieldCapFilter = FieldCapsFilter(clusterService, settings, indexNameExpressionResolver)
+        val originalIsmResponse = ISMFieldCapabilitiesResponse(arrayOf(), mapOf(), listOf(randomISMFieldCapabilitiesIndexResponse()))
+        val rewrittenResponse = fieldCapFilter.rewriteResponse(originalIsmResponse.toFieldCapabilitiesResponse(), setOf(rollupIndex), false) as FieldCapabilitiesResponse
+        val rewrittenIsmResponse = ISMFieldCapabilitiesResponse.fromFieldCapabilitiesResponse(rewrittenResponse)
+        assertEquals("Expected merged response to be empty, indices not empty", 0, rewrittenResponse.indices.size)
+        assertEquals("Expected merged response to be empty, map is empty", 0, rewrittenResponse.get().size)
+        assertEquals("Expected unmerged response sizes are different", originalIsmResponse.indexResponses.size + 1, rewrittenIsmResponse.indexResponses.size)
+    }
+
+    fun `test rewrite unmerged response discarding existing response`() {
+        val fieldCapFilter = FieldCapsFilter(clusterService, settings, indexNameExpressionResolver)
+        val originalIsmResponse = ISMFieldCapabilitiesResponse(arrayOf(), mapOf(), listOf(randomISMFieldCapabilitiesIndexResponse()))
+        val rewrittenResponse = fieldCapFilter.rewriteResponse(originalIsmResponse.toFieldCapabilitiesResponse(), setOf(rollupIndex), true) as
+            FieldCapabilitiesResponse
+        val rewrittenIsmResponse = ISMFieldCapabilitiesResponse.fromFieldCapabilitiesResponse(rewrittenResponse)
+        assertEquals("Expected merged response to be empty, indices not empty", 0, rewrittenResponse.indices.size)
+        assertEquals("Expected merged response to be empty, map is empty", 0, rewrittenResponse.get().size)
+        assertEquals("Expected unmerged response sizes are different", 1, rewrittenIsmResponse.indexResponses.size)
+    }
+
+    fun `test rewrite merged response`() {
+        val fieldCapFilter = FieldCapsFilter(clusterService, settings, indexNameExpressionResolver)
+        val ismResponse = randomISMFieldCaps()
+        val originalIsmResponse = ISMFieldCapabilitiesResponse(ismResponse.indices, ismResponse.responseMap, listOf())
+        val rewrittenResponse = fieldCapFilter.rewriteResponse(originalIsmResponse.toFieldCapabilitiesResponse(), setOf(rollupIndex), true) as
+            FieldCapabilitiesResponse
+        val rewrittenIsmResponse = ISMFieldCapabilitiesResponse.fromFieldCapabilitiesResponse(rewrittenResponse)
+        assertTrue("Expected unmerged response to be empty", rewrittenIsmResponse.indexResponses.isEmpty())
+    }
+}

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeTests.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.opendistroforelasticsearch.indexmanagement.rollup.actionfilter
 
 import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.randomISMFieldCaps

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/actionfilter/SerDeTests.kt
@@ -1,0 +1,23 @@
+package com.amazon.opendistroforelasticsearch.indexmanagement.rollup.actionfilter
+
+import com.amazon.opendistroforelasticsearch.indexmanagement.rollup.randomISMFieldCaps
+import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse
+import org.elasticsearch.test.ESTestCase
+
+class SerDeTests : ESTestCase() {
+
+    fun `test round trip empty`() {
+        val fieldCaps = FieldCapabilitiesResponse(arrayOf(), mapOf())
+        val roundTripFromFieldCaps = ISMFieldCapabilitiesResponse.fromFieldCapabilitiesResponse(fieldCaps).toFieldCapabilitiesResponse()
+        assertEquals("Round tripping didn't work", fieldCaps, roundTripFromFieldCaps)
+    }
+
+    fun `test round trip nonempty`() {
+        val ismFieldCaps = randomISMFieldCaps()
+        val fieldCaps = ismFieldCaps.toFieldCapabilitiesResponse()
+        val roundTrippedFieldCaps = ISMFieldCapabilitiesResponse.fromFieldCapabilitiesResponse(fieldCaps).toFieldCapabilitiesResponse()
+        assertEquals("Round tripping didn't work", fieldCaps, roundTrippedFieldCaps)
+        assertEquals("Expected indices are different", ismFieldCaps.indices.size, roundTrippedFieldCaps.indices.size)
+        assertEquals("Expected response map is different", ismFieldCaps.responseMap.size, roundTrippedFieldCaps.get().size)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/index-management/issues/418

https://github.com/opendistro-for-elasticsearch/index-management/issues/424

*Description of changes:*
Update `FieldCaps` interception to support remote cluster indices, and also supporting both merged and unmerged response rewriting of FieldCapsResponse.
* FieldCapsResponse hold unmerged data if its a cross cluster request and merged otherwise. Earlier we were only rewriting merged data.
* Introducing a setting to stop interception in case user isn't using rollup - this acts like a kill switch if there are any unexpected behavior from the interception.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
