### PR TITLE
Fixes ISM template matching

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -315,12 +315,11 @@ class ManagedIndexCoordinator(
     suspend fun getISMTemplates(): Map<String, ISMTemplate> {
         val searchRequest = SearchRequest()
             .source(
-                SearchSourceBuilder().query(
-                    QueryBuilders.existsQuery(ISM_TEMPLATE_FIELD)
-                )
+                SearchSourceBuilder()
+                .query(QueryBuilders.existsQuery(ISM_TEMPLATE_FIELD))
+                .size(MAX_HITS) // Assuming there are not more than 10k policies for now
             )
             .indices(INDEX_MANAGEMENT_INDEX)
-            .size(MAX_HITS) // Assuming there are not more than 10k policies for now
 
         return try {
             val response: SearchResponse = client.suspendUntil { search(searchRequest, it) }

--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/indexstatemanagement/ManagedIndexCoordinator.kt
@@ -320,6 +320,7 @@ class ManagedIndexCoordinator(
                 )
             )
             .indices(INDEX_MANAGEMENT_INDEX)
+            .size(MAX_HITS) // Assuming there are not more than 10k policies for now
 
         return try {
             val response: SearchResponse = client.suspendUntil { search(searchRequest, it) }


### PR DESCRIPTION
ISM template matching was only getting the first 10 policies

*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/index-management/issues/429

*Description of changes:*


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
