### PR TITLE
Fix: supporting custom type source indices in rollup

### DIFF
--- a/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMapperService.kt
+++ b/src/main/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMapperService.kt
@@ -146,8 +146,15 @@ class RollupMapperService(
                     return RollupJobValidationResult.Failure(getMappingsResult.message, getMappingsResult.cause)
             }
 
-            val indexMapping: MappingMetadata = res.mappings[index][_DOC]
-            val indexMappingSource = indexMapping.sourceAsMap
+            val indexTypeMappings = res.mappings[index]
+            if (indexTypeMappings.isEmpty) {
+                return RollupJobValidationResult.Invalid("Source index [$index] mappings are empty, cannot validate the job.")
+            }
+
+            // Starting from 6.0.0 an index can only have one mapping, but mapping type is still part of the APIs in 7.x
+            // Since a custom mapping type can be set for index using the first type mappings instead of _DOC mappings to validate
+            // https://www.elastic.co/guide/en/elasticsearch/reference/7.x/removal-of-types.html
+            val indexMappingSource = indexTypeMappings.first().value.sourceAsMap
 
             val issues = mutableSetOf<String>()
             // Validate source fields in dimensions
@@ -183,7 +190,9 @@ class RollupMapperService(
                 RollupJobValidationResult.Invalid("Invalid mappings for index [$index] because $issues")
             }
         } catch (e: Exception) {
-            return RollupJobValidationResult.Failure("Failed to validate the source index mappings", e)
+            val errorMessage = "Failed to validate the source index mappings"
+            logger.error(errorMessage, e)
+            return RollupJobValidationResult.Failure(errorMessage, e)
         }
     }
 

--- a/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMapperServiceTests.kt
+++ b/src/test/kotlin/com/amazon/opendistroforelasticsearch/indexmanagement/rollup/RollupMapperServiceTests.kt
@@ -56,7 +56,7 @@ class RollupMapperServiceTests : ESTestCase() {
         )
 
         val client = getClient(getAdminClient(getIndicesAdminClient(
-            getMappingsResponse = getKibanaSampleDataMappingResponse(sourceIndex),
+            getMappingsResponse = getMappingResponse(sourceIndex),
             getMappingsException = null
         )))
         val clusterService = getClusterService()
@@ -66,6 +66,66 @@ class RollupMapperServiceTests : ESTestCase() {
         runBlocking {
             val sourceIndexValidationResult = mapperService.isSourceIndexValid(rollup)
             require(sourceIndexValidationResult is RollupJobValidationResult.Valid) { "Source index validation returned unexpected results" }
+        }
+    }
+
+    fun `test source index validation with custom type`() {
+        val sourceIndex = "test-index"
+
+        val dimensions = listOf(randomDateHistogram().copy(
+            sourceField = "order_date"
+        ))
+        val metrics = listOf(randomRollupMetrics().copy(
+            sourceField = "total_quantity"
+        ))
+        val rollup = randomRollup().copy(
+            enabled = true,
+            jobEnabledTime = Instant.now(),
+            dimensions = dimensions,
+            metrics = metrics
+        )
+
+        val client = getClient(getAdminClient(getIndicesAdminClient(
+            getMappingsResponse = getMappingResponse(sourceIndex, "custom_type"),
+            getMappingsException = null
+        )))
+        val clusterService = getClusterService()
+        val indexNameExpressionResolver = getIndexNameExpressionResolver(listOf(sourceIndex))
+        val mapperService = RollupMapperService(client, clusterService, indexNameExpressionResolver)
+
+        runBlocking {
+            val sourceIndexValidationResult = mapperService.isSourceIndexValid(rollup)
+            require(sourceIndexValidationResult is RollupJobValidationResult.Valid) { "Source index validation returned unexpected results" }
+        }
+    }
+
+    fun `test source index validation with empty mappings`() {
+        val sourceIndex = "test-index"
+
+        val dimensions = listOf(randomDateHistogram().copy(
+            sourceField = "order_date"
+        ))
+        val metrics = listOf(randomRollupMetrics().copy(
+            sourceField = "total_quantity"
+        ))
+        val rollup = randomRollup().copy(
+            enabled = true,
+            jobEnabledTime = Instant.now(),
+            dimensions = dimensions,
+            metrics = metrics
+        )
+
+        val client = getClient(getAdminClient(getIndicesAdminClient(
+            getMappingsResponse = getMappingResponse(sourceIndex, "custom_type", true),
+            getMappingsException = null
+        )))
+        val clusterService = getClusterService()
+        val indexNameExpressionResolver = getIndexNameExpressionResolver(listOf(sourceIndex))
+        val mapperService = RollupMapperService(client, clusterService, indexNameExpressionResolver)
+
+        runBlocking {
+            val sourceIndexValidationResult = mapperService.isSourceIndexValid(rollup)
+            require(sourceIndexValidationResult is RollupJobValidationResult.Invalid) { "Source index validation returned unexpected results" }
         }
     }
 
@@ -86,7 +146,7 @@ class RollupMapperServiceTests : ESTestCase() {
         )
 
         val client = getClient(getAdminClient(getIndicesAdminClient(
-            getMappingsResponse = getKibanaSampleDataMappingResponse(sourceIndex),
+            getMappingsResponse = getMappingResponse(sourceIndex),
             getMappingsException = null
         )))
         val clusterService = getClusterService()
@@ -116,7 +176,7 @@ class RollupMapperServiceTests : ESTestCase() {
         )
 
         val client = getClient(getAdminClient(getIndicesAdminClient(
-            getMappingsResponse = getKibanaSampleDataMappingResponse(sourceIndex),
+            getMappingsResponse = getMappingResponse(sourceIndex),
             getMappingsException = null
         )))
         val clusterService = getClusterService()
@@ -143,7 +203,7 @@ class RollupMapperServiceTests : ESTestCase() {
         )
 
         val client = getClient(getAdminClient(getIndicesAdminClient(
-            getMappingsResponse = getKibanaSampleDataMappingResponse(sourceIndex),
+            getMappingsResponse = getMappingResponse(sourceIndex),
             getMappingsException = null
         )))
         val clusterService = getClusterService()
@@ -188,16 +248,19 @@ class RollupMapperServiceTests : ESTestCase() {
     private fun getIndexNameExpressionResolver(concreteIndices: List<String>): IndexNameExpressionResolver =
         mock { on { concreteIndexNames(any(), any(), anyVararg<String>()) } doReturn concreteIndices.toTypedArray() }
 
-    private fun getKibanaSampleDataMappingResponse(indexName: String): GetMappingsResponse {
-        val mappingSourceMap = createParser(
-            XContentType.JSON.xContent(),
-            javaClass.classLoader.getResource("mappings/kibana-sample-data.json").readText()
-        ).map()
-        val mappingMetadata = MappingMetadata(_DOC, mappingSourceMap)
-
-        val docMappings = ImmutableOpenMap.Builder<String, MappingMetadata>()
-            .fPut(_DOC, mappingMetadata)
-            .build()
+    private fun getMappingResponse(indexName: String, mappingType: String = _DOC, emptyMapping: Boolean = false): GetMappingsResponse {
+        val docMappings = if (emptyMapping) {
+            ImmutableOpenMap.Builder<String, MappingMetadata>().build()
+        } else {
+            val mappingSourceMap = createParser(
+                XContentType.JSON.xContent(),
+                javaClass.classLoader.getResource("mappings/kibana-sample-data.json").readText()
+            ).map()
+            val mappingMetadata = MappingMetadata(mappingType, mappingSourceMap)
+            ImmutableOpenMap.Builder<String, MappingMetadata>()
+                .fPut(mappingType, mappingMetadata)
+                .build()
+        }
 
         val mappings = ImmutableOpenMap.Builder<String, ImmutableOpenMap<String, MappingMetadata>>()
             .fPut(indexName, docMappings)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Rollup jobs fail if source index is using custom type instead of default `_DOC`

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
