### PR TITLE
Bumps jackson version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,9 +70,11 @@ configurations.all {
         force 'org.apache.httpcomponents:httpclient-osgi:4.5.13'
         force 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
         force 'org.apache.httpcomponents.client5:httpclient5-osgi:5.0.3'
-        force 'com.fasterxml.jackson.core:jackson-databind:2.11.4'
-        force 'com.fasterxml.jackson.core:jackson-core:2.11.4'
-        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+        force 'com.fasterxml.jackson.core:jackson-core:2.13.2'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.2'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2'
         force 'org.yaml:snakeyaml:1.26'
         force 'org.codehaus.plexus:plexus-utils:3.0.24'
     }
@@ -135,7 +137,7 @@ dependencies {
     compile "com.amazon.opendistroforelasticsearch:notification:1.13.1.0"
     compile "com.amazon.opendistroforelasticsearch:common-utils:1.13.0.0"
     compile "com.github.seancfoley:ipaddress:5.3.3"
-    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.11.4"
+    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2"
 
     testCompile "org.elasticsearch.test:framework:${es_version}"
     testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

*Issue #, if available:*

*Description of changes:*
Bumps jackson dependency from 2.11.4 to 2.13.2.2 to resolve [CVE-2020-36518 ](https://github.com/advisories/GHSA-57j2-w4cx-62h2)

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
