### PR TITLE
Bumps odfe version to 1.13.2.1 for patch release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ ext {
 }
 
 group = "com.amazon.opendistroforelasticsearch"
-version = "${opendistroVersion}.0"
+version = "${opendistroVersion}.1"
 
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

*Issue #, if available:*

*Description of changes:*
Bumps odfe version for patch release 1.13.2.1.
Following this PR to bump the jackson version https://github.com/opendistro-for-elasticsearch/index-management/pull/466 the opendistro version needs to be bumped to reflect the patch release.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
