### PR TITLE
Bumps opendistro version to 1.13.2.1 and jackson version to 2.13.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,11 @@ configurations.all {
         force 'org.apache.httpcomponents:httpclient-osgi:4.5.13'
         force 'org.apache.httpcomponents.client5:httpclient5:5.0.3'
         force 'org.apache.httpcomponents.client5:httpclient5-osgi:5.0.3'
-        force 'com.fasterxml.jackson.core:jackson-databind:2.10.4'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+        force 'com.fasterxml.jackson.core:jackson-core:2.13.2'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.2'
+        force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2'
         force 'org.yaml:snakeyaml:1.26'
         force 'org.codehaus.plexus:plexus-utils:3.0.24'
     }
@@ -133,6 +137,7 @@ dependencies {
     compile "com.amazon.opendistroforelasticsearch:notification:1.13.1.0"
     compile "com.amazon.opendistroforelasticsearch:common-utils:1.13.0.0"
     compile "com.github.seancfoley:ipaddress:5.3.3"
+    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2"
 
     testCompile "org.elasticsearch.test:framework:${es_version}"
     testCompile "org.jetbrains.kotlin:kotlin-test:${kotlin_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ ext {
 }
 
 group = "com.amazon.opendistroforelasticsearch"
-version = "${opendistroVersion}.0"
+version = "${opendistroVersion}.1"
 
 dependencies {
     compileOnly "org.elasticsearch:elasticsearch:${es_version}"


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
The two version bump PRs https://github.com/opendistro-for-elasticsearch/index-management/pull/467 and https://github.com/opendistro-for-elasticsearch/index-management/pull/466 were merged to main for the 1.13.2.1 patch release, however there are other commits on main which resulted in unwanted features going into the release. We have branched from the point of the 1.13.2 release, and this PR adds back in the version bumps for the patch.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
